### PR TITLE
Use orocos_kdl_vendor for the Space ROS source build

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -93,10 +93,10 @@ repositories:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
     version: master
-  orocos_kinematics_dynamics:
+  orocos_kdl_vendor:
     type: git
-    url: https://github.com/ros2/orocos_kinematics_dynamics.git
-    version: ros2
+    url: https://github.com/ros2/orocos_kdl_vendor.git
+    version: main
   osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
When doing a source build, some packages depend on orocos_kdl_vendor (which builds orocos_kinematics_dynamics), such as:

- kdl_parser/kdl_parser/package.xml
- kdl_parser/kdl_parser_py/package.xml
- geometry2/tf2_kdl/package.xml
- geometry2/tf2_geometry_msgs/package.xml
- geometry2/tf2_eigen_kdl/package.xml
- robot_state_publisher/package.xml
- orocos_kdl_vendor/python_orocos_kdl_vendor/package.xml
- orocos_kdl_vendor/orocos_kdl_vendor/package.xml

orocos_kdl_vendor builds orocos_kinematics_dynamics. Change to use the vendor package instead to avoid a build-time dependency error (where the orocos_kdl_vendor package is not present).

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>