### PR TITLE
Fix ament cobra branch in spaceros repos overrides.

### DIFF
--- a/spaceros.repos
+++ b/spaceros.repos
@@ -4,7 +4,7 @@ repositories:
   ament_cobra:
     type: git
     url: https://github.com/ament/ament_cobra.git
-    version: main
+    version: master
   ament_ikos:
     type: git
     url: https://github.com/ament/ament_ikos.git


### PR DESCRIPTION
This mistake was introduced in #43.