### PR TITLE
Revert the launch repo back to 'master' now that #588 has been fixed

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -71,7 +71,7 @@ repositories:
   launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: edcca09e4f80278d1a76e9c30eefbeeece5b33fd
+    version: master
   launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git

--- a/spaceros.repos
+++ b/spaceros.repos
@@ -13,9 +13,3 @@ repositories:
     type: git
     url: https://github.com/ament/ament_lint.git
     version: spaceros
-  launch:
-    type: git
-    url: https://github.com/ros2/launch.git
-    # Avoid an issue that breaks the MoveIt2 build: https://github.com/ros2/launch/issues/588
-    # TODO: Revert to 'master' when this issue is fixed
-    version: edcca09e4f80278d1a76e9c30eefbeeece5b33fd


### PR DESCRIPTION
Issue https://github.com/ros2/launch/issues/588 in launch fixed by: https://github.com/ros2/launch/pull/640

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>