### PR TITLE
Rebase space-ros onto Humble release track.

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -63,7 +63,7 @@ repositories:
   iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
-    version: 2.0.2
+    version: v2.0.2
   kdl_parser:
     type: git
     url: https://github.com/ros/kdl_parser.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -3,11 +3,11 @@ repositories:
   ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: master
+    version: 1.3.2
   ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: master
+    version: 0.10.0
   ament_cobra:
     type: git
     url: https://github.com/ament/ament_cobra.git
@@ -19,7 +19,7 @@ repositories:
   ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: master
+    version: 1.4.0
   ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
@@ -27,220 +27,220 @@ repositories:
   ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: master
+    version: 0.14.0
   class_loader:
     type: git
     url: https://github.com/ros/class_loader.git
-    version: ros2
+    version: 2.2.0
   common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: master
+    version: 4.2.2
   console_bridge_vendor:
     type: git
     url: https://github.com/ros2/console_bridge_vendor.git
-    version: master
+    version: 1.4.0
   cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: releases/0.9.x
+    version: 0.9.0
   eigen3_cmake_module:
     type: git
     url: https://github.com/ros2/eigen3_cmake_module.git
-    version: master
+    version: 0.1.1
   geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: ros2
+    version: 0.25.1
   google_benchmark_vendor:
     type: git
     url: https://github.com/ament/google_benchmark_vendor.git
-    version: main
+    version: 0.1.1
   googletest:
     type: git
     url: https://github.com/ament/googletest.git
-    version: ros2
+    version: 1.10.9004
   iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
-    version: release_2.0
+    version: 2.0.2
   kdl_parser:
     type: git
     url: https://github.com/ros/kdl_parser.git
-    version: ros2
+    version: 2.6.3
   launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: master
+    version: 1.0.2
   launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: master
+    version: 0.19.3
   libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
-    version: master
+    version: 1.2.0
   libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
-    version: master
+    version: 1.2.2
   message_filters:
     type: git
     url: https://github.com/ros2/message_filters.git
-    version: master
+    version: 4.3.2
   mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
-    version: master
+    version: 0.2.8
   orocos_kdl_vendor:
     type: git
     url: https://github.com/ros2/orocos_kdl_vendor.git
-    version: main
+    version: 0.2.4
   osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: master
+    version: 2.0.2
   osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
-    version: master
+    version: 1.5.1
   performance_test_fixture:
     type: git
     url: https://github.com/ros2/performance_test_fixture.git
-    version: main
+    version: 0.0.9
   pluginlib:
     type: git
     url: https://github.com/ros/pluginlib.git
-    version: ros2
+    version: 5.1.0
   pybind11_vendor:
     type: git
     url: https://github.com/ros2/pybind11_vendor.git
-    version: master
+    version: 2.4.1
   python_cmake_module:
     type: git
     url: https://github.com/ros2/python_cmake_module.git
-    version: master
+    version: 0.10.0
   rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: master
+    version: 5.3.1
   rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: master
+    version: 1.2.0
   rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
-    version: master
+    version: 2.3.0
   rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: master
+    version: 16.0.1
   rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: master
+    version: 3.3.4
   rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: master
+    version: 2.4.0
   rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
-    version: master
+    version: 5.1.1
   rmw:
     type: git
     url: https://github.com/ros2/rmw.git
-    version: master
+    version: 6.1.0
   rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
-    version: master
+    version: 1.3.3
   rmw_dds_common:
     type: git
     url: https://github.com/ros2/rmw_dds_common.git
-    version: master
+    version: 1.6.0
   rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: master
+    version: 2.8.1
   robot_state_publisher:
     type: git
     url: https://github.com/ros/robot_state_publisher.git
-    version: ros2
+    version: 3.0.2
   ros2_tracing:
     type: git
-    url: https://gitlab.com/ros-tracing/ros2_tracing.git
-    version: master
+    url: https://github.com/ros2/ros2_tracing.git
+    version: 4.1.0
   ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: master
+    version: 0.18.3
   ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git
-    version: rolling
+    version: 3.2.1
   ros_testing:
     type: git
     url: https://github.com/ros2/ros_testing.git
-    version: master
+    version: 0.4.0
   rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: master
+    version: 3.1.3
   rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: master
+    version: 1.2.0
   rosidl_python:
     type: git
     url: https://github.com/ros2/rosidl_python.git
-    version: master
+    version: 0.14.2
   rosidl_runtime_py:
     type: git
     url: https://github.com/ros2/rosidl_runtime_py.git
-    version: master
+    version: 0.9.2
   rosidl_typesupport:
     type: git
     url: https://github.com/ros2/rosidl_typesupport.git
-    version: master
+    version: 2.0.0
   rpyutils:
     type: git
     url: https://github.com/ros2/rpyutils.git
-    version: master
+    version: 0.2.1
   spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
-    version: master
+    version: 1.3.0
   test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git
-    version: master
+    version: 0.9.1
   tinyxml2_vendor:
     type: git
     url: https://github.com/ros2/tinyxml2_vendor.git
-    version: master
+    version: 0.7.5
   tinyxml_vendor:
     type: git
     url: https://github.com/ros2/tinyxml_vendor.git
-    version: master
+    version: 0.8.3
   uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
-    version: master
+    version: 2.0.2
   unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: master
+    version: 2.2.1
   urdf:
     type: git
     url: https://github.com/ros2/urdf.git
-    version: ros2
+    version: 2.6.0
   urdfdom:
     type: git
     url: https://github.com/ros/urdfdom.git
-    version: master
+    version: 3.0.2
   urdfdom_headers:
     type: git
     url: https://github.com/ros/urdfdom_headers.git
-    version: master
+    version: 1.0.6

--- a/scripts/generate-repos.sh
+++ b/scripts/generate-repos.sh
@@ -11,7 +11,7 @@ usage() {
 }
 
 OUTFILE=${1:-ros2.repos}
-ROSDISTRO=${ROSDISTRO:-rolling}
+ROSDISTRO=${ROSDISTRO:-humble}
 
 GENERATE_CMD=rosinstall_generator
 # Use the repos file format rather than rosinstall format.

--- a/scripts/generate-repos.sh
+++ b/scripts/generate-repos.sh
@@ -24,7 +24,7 @@ GENERATE_CMD="$GENERATE_CMD --deps"
 
 # Use upstream repositories rather than release repositories and
 # use development branches rather than tags.
-GENERATE_CMD="$GENERATE_CMD --upstream-development"
+GENERATE_CMD="$GENERATE_CMD --upstream"
 
 # Exclude packages which we don't incorporate into Space ROS
 excluded_pkgs=$(cat excluded-pkgs.txt)

--- a/spaceros-pkgs.txt
+++ b/spaceros-pkgs.txt
@@ -13,8 +13,8 @@ gmock_vendor
 google_benchmark_vendor
 gtest_vendor
 iceoryx_binding_c
+iceoryx_hoofs
 iceoryx_posh
-iceoryx_utils
 launch
 launch_ros
 rcl

--- a/spaceros.repos
+++ b/spaceros.repos
@@ -13,3 +13,7 @@ repositories:
     type: git
     url: https://github.com/ament/ament_lint.git
     version: spaceros
+  iceoryx:
+    type: git
+    url: https://github.com/eclipse-iceoryx/iceoryx.git
+    version: v2.0.2


### PR DESCRIPTION
This PR includes a few updates to the Space ROS repos file generation scripts in order to base the Space ROS project on the ROS 2 release Humble Hawksbill.

Basing Space ROS on a released version of ROS has been the plan from the beginning with the intent to use Rolling until the first Humble release was available.

Switching from Rolling to Humble reduces the amount of incoming changes from upstream, this makes any patches in Space ROS easier to maintain at the cost of making it harder to integrate breaking improvements from upstream even if they're Space ROS related. In previous discussions the overall benefits of a stable base were deemed greater than the additional challenges and restrictions.

Switching specifically to the _release_ track of Humble is a furthering of the decision above which has two concrete improvements over tracking the development branches of Humble packages.
1. Since the release track will use tags rather than branches, there will be a stronger tie between the repos file contents and the exact sources used by our docker image builds which will improve the caching and cache invalidation story considerably. It's not a completely immutable repos file because packages added specifically for Space ROS are still using development branches. For now I think this is still the best approach as adding release procedures for Space ROS-only packages at this juncture will impede velocity with very minor benefit if the scope of those repositories grows it may make sense to switch to exact commit ids or tags there as well.
2. Since Humble releases are made at an explicit cadence of approximately twice per month, this will help make maintaining Space ROS more predictable since we know that regenerating the ros2.repos file is something that will need to be done for each new release ("sync", in the parlance of the ROS 2 community) of the ROS 2 Humble Hawksbill distribution.