### PR TITLE
Add Earthly configuration and GitHub Actions workflow for regenerating Space ROS repos file

### DIFF
--- a/.github/workflows/vcs-repos.yaml
+++ b/.github/workflows/vcs-repos.yaml
@@ -19,8 +19,6 @@ jobs:
           sudo chmod 755 /usr/local/bin/earthly
       - name: Regenerate ros2.repos
         run: earthly +repos-file
-      - name: Check for changes
-        run: earthly +repos-file
       - name: Diff ros2.repos to determine if there have been changes
         id: diff
         run: |

--- a/.github/workflows/vcs-repos.yaml
+++ b/.github/workflows/vcs-repos.yaml
@@ -22,4 +22,15 @@ jobs:
       - name: Check for changes
         run: earthly +repos-file
       - name: Diff ros2.repos to determine if there have been changes
-        run: git diff ros2.repos
+        id: diff
+        run: |
+          if git diff --exit-code ros2.repos; then
+            echo "::set-output name=updated::false"
+          else
+            echo "::set-output name=updated::true"
+          fi
+      - name: Commit updated ros2.repos file
+        if: steps.diff.outputs.updated == true
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: ros2.repos

--- a/.github/workflows/vcs-repos.yaml
+++ b/.github/workflows/vcs-repos.yaml
@@ -1,0 +1,25 @@
+---
+name: Generate vcstool repos file.
+
+on:
+  push:
+    branches:
+      - '*'
+
+jobs:
+  update_ros2_repos:
+    name: Update ros2.repos file
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v2
+      - name: Install Earthly
+        run: |
+          sudo wget 'https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64' -O /usr/local/bin/earthly
+          sudo chmod 755 /usr/local/bin/earthly
+      - name: Regenerate ros2.repos
+        run: earthly +repos-file
+      - name: Check for changes
+        run: earthly +repos-file
+      - name: Diff ros2.repos to determine if there have been changes
+        run: git diff ros2.repos

--- a/.github/workflows/vcs-repos.yaml
+++ b/.github/workflows/vcs-repos.yaml
@@ -30,7 +30,7 @@ jobs:
             echo "::set-output name=updated::true"
           fi
       - name: Commit updated ros2.repos file
-        if: steps.diff.outputs.updated == true
+        if: ${{ steps.diff.outputs.updated == 'true' }}
         uses: EndBug/add-and-commit@v9
         with:
           add: ros2.repos

--- a/Earthfile
+++ b/Earthfile
@@ -18,17 +18,13 @@ FROM ubuntu:jammy
 repos-file:
   # Disable prompting during package installation
   ARG DEBIAN_FRONTEND=noninteractive
-  
-  # The following commands are based on the source install for ROS 2 Rolling Ridley.
-  # See: https://docs.ros.org/en/ros2_documentation/rolling/Installation/Ubuntu-Development-Setup.html
-  # The main variation is getting Space ROS sources instead of the Rolling sources.
-  
+
   # Set the locale
   RUN apt-get update && apt-get install -y locales
   RUN locale-gen en_US en_US.UTF-8
   RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
   ENV LANG=en_US.UTF-8
-  
+
   # Add the ROS 2 apt repository
   RUN apt-get install -y software-properties-common
   RUN add-apt-repository universe
@@ -46,5 +42,3 @@ repos-file:
   RUN sh scripts/generate-repos.sh
   RUN ruby scripts/merge-repos.rb
   SAVE ARTIFACT ros2.repos AS LOCAL ros2.repos
-
-

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,50 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+VERSION 0.6
+
+FROM ubuntu:jammy
+
+repos-file:
+  # Disable prompting during package installation
+  ARG DEBIAN_FRONTEND=noninteractive
+  
+  # The following commands are based on the source install for ROS 2 Rolling Ridley.
+  # See: https://docs.ros.org/en/ros2_documentation/rolling/Installation/Ubuntu-Development-Setup.html
+  # The main variation is getting Space ROS sources instead of the Rolling sources.
+  
+  # Set the locale
+  RUN apt-get update && apt-get install -y locales
+  RUN locale-gen en_US en_US.UTF-8
+  RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+  ENV LANG=en_US.UTF-8
+  
+  # Add the ROS 2 apt repository
+  RUN apt-get install -y software-properties-common
+  RUN add-apt-repository universe
+  RUN apt-get update && apt-get install -y curl gnupg lsb-release
+  RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+  RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+  # Install repos file generator script requirements.
+  RUN apt-get install -y python3-rosinstall-generator ruby
+  WORKDIR /root
+  COPY --dir scripts/ ./
+  COPY excluded-pkgs.txt ./
+  COPY spaceros-pkgs.txt ./
+  COPY spaceros.repos ./
+  RUN sh scripts/generate-repos.sh
+  RUN ruby scripts/merge-repos.rb
+  SAVE ARTIFACT ros2.repos AS LOCAL ros2.repos
+
+

--- a/ros2.repos
+++ b/ros2.repos
@@ -115,7 +115,7 @@ repositories:
   process_sarif:
     type: git
     url: https://github.com/space-ros/process_sarif.git
-    version: build-results-archive
+    version: main
   pybind11_vendor:
     type: git
     url: https://github.com/ros2/pybind11_vendor.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -112,6 +112,10 @@ repositories:
     type: git
     url: https://github.com/ros/pluginlib.git
     version: 5.1.0
+  process_sarif:
+    type: git
+    url: https://github.com/space-ros/process_sarif.git
+    version: build-results-archive
   pybind11_vendor:
     type: git
     url: https://github.com/ros2/pybind11_vendor.git
@@ -123,7 +127,7 @@ repositories:
   rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 5.3.1
+    version: 5.3.2
   rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -71,7 +71,7 @@ repositories:
   launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: 1.0.2
+    version: 1.0.3
   launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git


### PR DESCRIPTION
This PR adds an Earthly recipe which uses the repos file generation scripts already present in this repository to generate the Space ROS repos file with no additional setup or dependencies on the local host beyond Earthly and Docker.

The GitHub action, triggered on push, will regenerate and commit changes to the ros2.repos file whenever they occcur due to updates to the spaceros-pkgs.txt, excluded-pkgs.txt, or spaceros.repos files.