### PR TITLE
Add process_sarif to Space ROS repos.

### DIFF
--- a/spaceros.repos
+++ b/spaceros.repos
@@ -17,3 +17,7 @@ repositories:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
     version: v2.0.2
+process_sarif:
+    type: git
+    url: https://github.com/space-ros/process_sarif.git
+    version: main


### PR DESCRIPTION
This package is being used to pre-process SARIF and bundle results into an archive for storage and comparison to future builds.