### PR TITLE
Fix link to contributing guide (Close #89).

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Documentation is at https://space.ros.org
 
 # Contribution rules
 
-See the [contributing guide](Contributing.md) for details on how to contribute
+See the [contributing guide](CONTRIBUTING.md) for details on how to contribute
 to the Space ROS project.


### PR DESCRIPTION
The link to the contributing guide in the readme points to the file in lowercase, but the file name is uppercase. Github does not resolve the link correctly, resulting in a 404 when clicked.

This commit changes the link to point to the right file.

This issue was introduced in the recently closed issue #76 .