### PR TITLE
Fix earthly-triggered update script (#98).

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -39,6 +39,6 @@ repos-file:
   COPY excluded-pkgs.txt ./
   COPY spaceros-pkgs.txt ./
   COPY spaceros.repos ./
-  RUN sh scripts/generate-repos.sh
-  RUN ruby scripts/merge-repos.rb
+  RUN --no-cache sh scripts/generate-repos.sh
+  RUN --no-cache ruby scripts/merge-repos.rb
   SAVE ARTIFACT ros2.repos AS LOCAL ros2.repos


### PR DESCRIPTION
## Description of changes
This commit fixes https://github.com/space-ros/space-ros/issues/98, by forcing earthly to re-run the script every time the command is invoked.

Although I was not able to reproduce the issue, I suspect that the root cause of the problem is that if no files change in the repository between consecutive runs, then earthly simply uses cached results (as described in [Earthly docs](https://docs.earthly.dev/docs/caching/caching-in-earthfiles#layer-caching)). In that case scripts are never executed, and in turn packages never updated.

**Note that I did not update ros2.repos file to the latest version in this PR**, see the issue for more details.

## How changes were tested
Changes were tested locally:
| Scenario                                                          | Expected outcome                                            | Succeed?           |
|-------------------------------------------------------------------|-------------------------------------------------------------|--------------------|
| Trigger earthly when older ros2.repos file is present in the repo | ros2.repos file is updated to the latest package versions   | :white_check_mark: |
| Trigger earthly when ros2.repos file does not exist               | ros2.repos file is created with the latest package versions | :white_check_mark: |
