### PR TITLE
Fix outdated usage and comments in `generate-repos.sh`

### DIFF
--- a/scripts/generate-repos.sh
+++ b/scripts/generate-repos.sh
@@ -4,9 +4,9 @@ usage() {
   echo "$0 [OUTPUT_FILENAME]"
 
   echo "	Generate a spaceros repos file containing packages listed in spaceros-pkgs.txt"
-  echo "	and their dependencies excluding packages in excluded-pkgs.txt"
+  echo "	and their dependencies, excluding packages in excluded-pkgs.txt"
   echo "	Set the ROSDISTRO environment variable to change the target ROS distribution."
-  echo "	By default it is 'rolling'."
+  echo "	By default it is 'humble'."
   exit 0
 }
 
@@ -22,8 +22,7 @@ GENERATE_CMD="$GENERATE_CMD --rosdistro $ROSDISTRO"
 # Include all dependencies
 GENERATE_CMD="$GENERATE_CMD --deps"
 
-# Use upstream repositories rather than release repositories and
-# use development branches rather than tags.
+# Use version tags of upstream repositories
 GENERATE_CMD="$GENERATE_CMD --upstream"
 
 # Exclude packages which we don't incorporate into Space ROS
@@ -31,7 +30,7 @@ excluded_pkgs=$(cat excluded-pkgs.txt)
 GENERATE_CMD="$GENERATE_CMD --exclude $excluded_pkgs --"
 
 # Use Space ROS packages as base package list
-# This list should stay small rosinstall_generator will resolve dependencies.
+# This list should stay small, rosinstall_generator will resolve dependencies.
 spaceros_pkgs=$(cat spaceros-pkgs.txt)
 GENERATE_CMD="$GENERATE_CMD $spaceros_pkgs"
 


### PR DESCRIPTION
The text was originally correct but was not updated along with the code changes in commits:
 - https://github.com/space-ros/space-ros/commit/112e379ca0c470081beddee0064d0627efe4415a
 - https://github.com/space-ros/space-ros/commit/e1fb018344898e8869f756923a495c44bf273aa2

Closes #109