### PR TITLE
Add version pinning for Space ROS repos (#101).

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -33,12 +33,20 @@ repos-file:
   RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
   # Install repos file generator script requirements.
-  RUN apt-get install -y python3-rosinstall-generator ruby
+  RUN apt-get update && apt-get install -y python3-rosinstall-generator ruby python3-vcstool git
   WORKDIR /root
   COPY --dir scripts/ ./
   COPY excluded-pkgs.txt ./
   COPY spaceros-pkgs.txt ./
   COPY spaceros.repos ./
+
+  # generate `ros2.repos` file with rosinstall script
   RUN --no-cache sh scripts/generate-repos.sh
+  # merge `ros2.repos` file with `spaceros.repos` file
   RUN --no-cache ruby scripts/merge-repos.rb
+  RUN mkdir src
+  # clone all dependencies to export `.repos` file with exact tags / commit hashes
+  # this way we can be certain that we always pull same versions of dependent packages
+  RUN --no-cache vcs import src < ros2.repos
+  RUN --no-cache vcs export --exact-with-tags --nested src > ros2.repos
   SAVE ARTIFACT ros2.repos AS LOCAL ros2.repos


### PR DESCRIPTION
## Summary
Addresses https://github.com/space-ros/space-ros/issues/101

This PR adds version pinning to generated `ros2.repos`  file. Now all packages in `ros2.repos` file will point to static ref (either tag or commit hash).

## Out of scope for this PR
- Generate and commit new `ros2.repos` file
- Create proper tags for repos in `spaceros.repos` file -> for now `ros2.repos` file will point to commit hashes.
