### PR TITLE
Make excluded pkgs consistent across rosdep and vcs (space-ros/docker/#88).

### DIFF
--- a/excluded-pkgs.txt
+++ b/excluded-pkgs.txt
@@ -7,3 +7,6 @@ rmw_connextdds
 rosidl_typesupport_fastrtps_c
 rosidl_typesupport_fastrtps_cpp
 fastrtps_cmake_module
+demo_nodes_py
+composition
+lifecycle


### PR DESCRIPTION
This PR addresses https://github.com/space-ros/docker/issues/88
Now 'excluded-pkgs.txt' can be used both to create list of repos (vcs), as well as to install necessary system dependencies (rosdep).

I have compared `ros2.repos` files before and after applying the fix and there is no diff whatsoever, which is expected :)