### PR TITLE
Pin version of IKOS in `ikos.repos` (#137).

### DIFF
--- a/ikos.repos
+++ b/ikos.repos
@@ -2,4 +2,4 @@ repositories:
   ikos:
     type: git
     url: https://github.com/NASA-SW-VnV/ikos.git
-    version: master
+    version: v3.2


### PR DESCRIPTION
This commit pins the version numbers of the ikos.repos, to match those in the latest release of IKOS (currently, v3.2).