### PR TITLE
Move spaceros Base Image from docker to space-ros

### DIFF
--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -1,0 +1,54 @@
+name: Earthly build
+on:
+  workflow_dispatch:
+  push:
+    branches: ['main']
+    tags: ['*']
+  pull_request:
+  schedule:
+    - cron: '0 11 * * *'
+jobs:
+  build-testing-results:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up earthly
+        run: |
+          sudo wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly
+          sudo chmod 755 /usr/local/bin/earthly
+      - name: Build Space ROS
+        id: build
+        run: |
+          cd spaceros
+          earthly --ci --output +sources
+          earthly --ci --output +build-testing
+          echo "archivename=$(basename log/build_results_archives/build_results_*.tar.bz2)" >> $GITHUB_ENV
+      - name: Upload build results archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{env.archivename}}
+          path: spaceros/log/build_results_archives/${{env.archivename}}
+          if-no-files-found: error
+  space-ros-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up earthly
+        run: |
+          sudo wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly
+          sudo chmod 755 /usr/local/bin/earthly
+      - name: Build spaceros image
+        run: |
+          cd spaceros
+          earthly --ci --output +sources
+          earthly --ci +image
+      - name: Push spaceros image
+        env:
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          echo $DOCKER_HUB_TOKEN | docker login --username osrfbot --password-stdin
+          cd spaceros
+          earthly --ci --push +image --tag=${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <img src="/logos/spaceros_white_on_blue.png" alt="Space ROS Logo - White on Blue" width="700"/>
 
-Documentation is at https://space.ros.org
+Documentation is at https://space.ros.org.
+
+For information on compiling the base Space ROS image see the [README](./spaceros/README.md).
 
 # Contribution rules
 
@@ -9,10 +11,12 @@ to the Space ROS project.
 
 # Release steps
 
-# Update ros2.repos file
+### Update ros2.repos file
+```
 git clone https://github.com/space-ros/space-ros.git
 cd space-ros
 git checkout -b <release-id>
 earthly build +repos-file
 git add ros2.repos
 git commit -m "Update repos file for <release-id> release"
+```

--- a/spaceros/.gitignore
+++ b/spaceros/.gitignore
@@ -1,0 +1,4 @@
+spaceros_ws/
+src/
+install/
+log/

--- a/spaceros/Earthfile
+++ b/spaceros/Earthfile
@@ -1,0 +1,220 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+VERSION 0.6
+FROM ubuntu:jammy
+
+earthfile:
+  COPY Earthfile Earthfile
+  SAVE ARTIFACT Earthfile
+
+setup:
+  # Disable prompting during package installation
+  ARG DEBIAN_FRONTEND=noninteractive
+
+  # The following commands are based on the source install for ROS 2 Rolling Ridley.
+  # See: https://docs.ros.org/en/ros2_documentation/rolling/Installation/Ubuntu-Development-Setup.html
+  # The main variation is getting Space ROS sources instead of the Rolling sources.
+  
+  # Update the Ubuntu software repository
+  RUN apt-get update
+  
+  # Set the locale
+  RUN apt-get install -y locales
+  RUN locale-gen en_US en_US.UTF-8
+  RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+  ENV LANG=en_US.UTF-8
+  
+  # Add the ROS 2 apt repository
+  RUN apt-get install -y software-properties-common
+  RUN add-apt-repository universe
+  RUN apt-get update && apt-get install -y curl gnupg lsb-release
+  RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+  RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+  
+  # Install required software development tools and ROS tools (and vim included for convenience)
+  RUN apt-get update && apt-get install -y \
+    bison \
+    build-essential \
+    cmake \
+    git \
+    python3-colcon-common-extensions \
+    python3-flake8 \
+    python3-flake8-blind-except \
+    python3-flake8-builtins \
+    python3-flake8-class-newline \
+    python3-flake8-comprehensions \
+    python3-flake8-deprecated \
+    python3-flake8-docstrings \
+    python3-flake8-import-order \
+    python3-flake8-quotes \
+    python3-pip \
+    python3-pytest \
+    python3-pytest-cov \
+    python3-pytest-repeat \
+    python3-pytest-rerunfailures \
+    python3-rosdep \
+    python3-setuptools \
+    python3-vcstool \
+    wget \
+    vim
+
+  # Define the username and key variables
+  ENV USERNAME spaceros-user
+  ENV HOME_DIR=/home/${USERNAME}
+  ENV SPACEROS_DIR=${HOME_DIR}/spaceros
+  ENV ROSDISTRO=humble
+
+  # Create a spaceros user
+  RUN useradd -m $USERNAME && \
+    echo "$USERNAME:$USERNAME" | chpasswd && \
+    usermod --shell /bin/bash $USERNAME && \
+    usermod -aG sudo $USERNAME && \
+    mkdir -p /etc/sudoers.d && \
+    echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME && \
+    chmod 0440 /etc/sudoers.d/$USERNAME
+  USER ${USERNAME}
+  WORKDIR $SPACEROS_DIR
+
+  # Update the OpenGL version
+  RUN sudo add-apt-repository ppa:kisak/kisak-mesa
+  RUN sudo apt update && sudo apt upgrade -y
+
+spaceros-artifacts:
+  # we must run it in a separate container, so that downstream tasks can be cached if vcs file does not change
+  FROM +setup
+
+  # main purpose of this command is to make sure that the git ls-remote results are not cached
+  RUN --no-cache echo "Cloning spaceros repo artifacts"
+
+  # current git branch, prefilled by earthly: https://docs.earthly.dev/docs/earthfile/builtin-args
+  ARG EARTHLY_GIT_BRANCH
+
+  ARG SPACEROS_REPO_URL="https://github.com/space-ros/space-ros.git"
+  # if current local branch does not exist in target repo then use main. note that branch supplied from CLI overrides this behavior.
+  ARG SPACEROS_GIT_REF="$( [ -n \"$(git ls-remote $SPACEROS_REPO_URL $EARTHLY_GIT_BRANCH)\" ] && echo $EARTHLY_GIT_BRANCH || echo 'main' )"
+  # get exact commit hash. this makes sure that build will be re-triggered when new commit is pushed 
+  ARG _GIT_COMMIT_HASH = "$(git ls-remote $SPACEROS_REPO_URL $SPACEROS_GIT_REF | cut -f 1)"
+
+  # this means that branch specified by user from CLI does not exist
+  IF [ -z ${_GIT_COMMIT_HASH} ] 
+    RUN echo "Specified branch ${SPACEROS_GIT_REF} does not exist" && exit 1
+  END
+
+  IF [ $SPACEROS_REPO_URL = "https://github.com/space-ros/space-ros.git" ] 
+    # run wget instead of `GIT CLONE`, because main repo's host is known + it is public 
+    RUN wget https://raw.githubusercontent.com/space-ros/space-ros/${_GIT_COMMIT_HASH}/ros2.repos
+    RUN wget https://raw.githubusercontent.com/space-ros/space-ros/${_GIT_COMMIT_HASH}/excluded-pkgs.txt
+  ELSE
+    GIT CLONE --branch ${SPACEROS_GIT_REF} ${SPACEROS_REPO_URL} .
+  END
+
+  RUN mkdir src
+  # we run vcstool inside this task, because some packages in `ros2.repos` are not pinned and otherwise earthly won't pull latest changes
+  RUN vcs import src < ros2.repos
+  RUN vcs export --exact src > exact.repos
+  RUN rm -rf src
+
+  SAVE ARTIFACT ros2.repos # vcs pulled from `spaceros` repo as-is
+  SAVE ARTIFACT exact.repos # `ros2.repos`, but with pinned versions (e.g. SHAs instead of branches)
+  SAVE ARTIFACT excluded-pkgs.txt
+
+sources:
+  FROM +setup
+  COPY +spaceros-artifacts/ros2.repos ros2.repos
+  COPY +spaceros-artifacts/excluded-pkgs.txt excluded-pkgs.txt
+  COPY +spaceros-artifacts/exact.repos exact.repos
+  RUN mkdir src
+  RUN vcs import src < exact.repos
+  SAVE ARTIFACT src AS LOCAL src
+
+workspace:
+  FROM +sources
+  COPY src src/
+
+vcs-exact:
+  COPY +spaceros-artifacts/exact.repos exact.repos
+  SAVE ARTIFACT exact.repos AS LOCAL exact.repos
+
+rosdep:
+  FROM +workspace
+  # Install system package dependencies using rosdep
+  RUN sudo rosdep init && rosdep update
+  RUN rosdep install -y \
+      --from-paths src --ignore-src \
+      --rosdistro ${ROSDISTRO} \
+      # `urdfdom_headers` is cloned from source, however rosdep can't find it.
+      # It is because package.xml manifest is missing. See: https://github.com/ros/urdfdom_headers
+      # Additionally, IKOS must be excluded as per: https://github.com/space-ros/docker/issues/99
+      --skip-keys "$(tr '\n' ' ' < 'excluded-pkgs.txt') urdfdom_headers ikos"
+  RUN rm excluded-pkgs.txt
+
+  RUN sudo apt-get install --yes \
+           gcc g++ cmake libgmp-dev libboost-dev libboost-filesystem-dev \
+           libboost-thread-dev libboost-test-dev \
+           libsqlite3-dev libtbb-dev libz-dev libedit-dev \
+           python3 python3-pip python3-venv \
+           llvm-14 llvm-14-dev llvm-14-tools clang-14
+
+  WORKDIR $SPACEROS_DIR
+  RUN git clone -b v3.2 --depth 1 https://github.com/NASA-SW-VnV/ikos.git
+  WORKDIR $SPACEROS_DIR/ikos
+  RUN mkdir build
+  WORKDIR $SPACEROS_DIR/ikos/build
+  RUN cmake \
+        -DCMAKE_INSTALL_PREFIX="/opt/ikos" \
+        -DCMAKE_BUILD_TYPE="Debug" \
+        -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-14/bin/llvm-config" \
+        ..
+  RUN make
+  RUN sudo make install
+  ENV PATH="/opt/ikos/bin/:$PATH"
+  WORKDIR $SPACEROS_DIR
+  RUN sudo rm -rf ikos/
+
+build:
+  FROM +rosdep
+  RUN colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli
+  COPY +spaceros-artifacts/exact.repos install/exact.repos
+  SAVE ARTIFACT install AS LOCAL install
+
+build-testing:
+  FROM +rosdep
+  RUN colcon build --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli
+  RUN . install/setup.sh && colcon test --retest-until-pass 2 --ctest-args -LE "(ikos|xfail)" --pytest-args -m "not xfail"
+  RUN . install/setup.sh && ros2 run process_sarif make_build_archive
+  COPY +spaceros-artifacts/exact.repos install/exact.repos
+  SAVE ARTIFACT log/build_results_archives/build_results_*.tar.bz2 AS LOCAL log/build_results_archives/
+  SAVE ARTIFACT install AS LOCAL install
+
+image:
+  FROM +rosdep
+  ARG VCS_REF
+  ARG tag='latest'
+
+  # Specify the docker image metadata
+  LABEL org.label-schema.schema-version="1.0"
+  LABEL org.label-schema.name="Space ROS"
+  LABEL org.label-schema.description="Preview version of the Space ROS platform"
+  LABEL org.label-schema.vendor="Open Robotics"
+  LABEL org.label-schema.url="https://github.com/space-ros"
+  LABEL org.label-schema.vcs-url="https://github.com/space-ros/docker-images"
+  LABEL org.label-schema.vcs-ref=${VCS_REF}
+
+  COPY +build/install ${SPACEROS_DIR}/install
+  COPY +spaceros-artifacts/exact.repos ${SPACEROS_DIR}/exact.repos
+  RUN rm -r src
+  COPY entrypoint.sh /ros_entrypoint.sh
+  ENTRYPOINT ["/ros_entrypoint.sh"]
+  CMD ["bash"]
+  SAVE IMAGE --push osrf/space-ros:latest osrf/space-ros:$tag

--- a/spaceros/README.md
+++ b/spaceros/README.md
@@ -1,0 +1,257 @@
+# Space ROS Docker Image and Earthly configuration
+
+The Earthfile configuration in this directory facilitates builds of Space ROS from source code.
+The generated container image is based on Ubuntu 22.04 (Jammy)
+
+## Building the Docker Image
+
+The [Earthly](https://earthly.dev/get-earthly) utility is required to build this image.
+
+To build the image, run:
+
+```bash
+./build.sh
+```
+
+The build process will take about 20 or 30 minutes, depending on the host computer.
+
+The build process defaults to cloning the `ros2.repos` file from [spaceros](https://github.com/space-ros/space-ros) repository.
+It looks for a branch with the same name as the current local branch; if it doesn't find one, it falls back to cloning from the main branch.
+For testing purposes, you can customize both the spaceros repository URL and the branch name by modifying arguments defined in the [Earthfile](./Earthfile).
+Example:
+```bash
+earthly +image --SPACEROS_REPO_URL="https://github.com/my-org/my-spaceros-fork.git" --SPACEROS_GIT_REF="my-branch-name"
+```
+
+## Running the Space ROS Docker Image in a Container
+
+After building the image, you can see the newly-built image by running:
+
+```bash
+docker image list
+```
+
+The output will look something like this:
+
+```
+$ docker image list
+REPOSITORY              TAG                        IMAGE ID       CREATED        SIZE
+osrf/space-ros        latest                     109ad8fb7460   4 days ago      2.45GB
+ubuntu                jammy                      a8780b506fa4   5 days ago      77.8MB
+```
+
+The new image is named **osrf/space-ros:latest**.
+
+There is a run.sh script provided for convenience that will run the spaceros image in a container.
+
+```bash
+./run.sh
+```
+
+Upon startup, the container automatically runs the entrypoint.sh script, which sources the Space ROS environment file (setup.bash).
+You'll now be running inside the container and should see a prompt similar to this:
+
+```
+spaceros-user@d10d85c68f0e:~/spaceros$
+```
+
+At this point, you can run the `ros2` command line utility to make sure everything is working OK:
+
+```
+spaceros-user@d10d85c68f0e:~/spaceros$ ros2
+usage: ros2 [-h] [--use-python-default-buffering] Call `ros2 <command> -h` for more detailed usage. ...
+
+ros2 is an extensible command-line tool for ROS 2.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --use-python-default-buffering
+                        Do not force line buffering in stdout and instead use the python default buffering, which might be affected by PYTHONUNBUFFERED/-u and depends on whatever stdout is interactive or not
+
+Commands:
+  action     Various action related sub-commands
+  component  Various component related sub-commands
+  daemon     Various daemon related sub-commands
+  doctor     Check ROS setup and other potential issues
+  interface  Show information about ROS interfaces
+  launch     Run a launch file
+  lifecycle  Various lifecycle related sub-commands
+  multicast  Various multicast related sub-commands
+  node       Various node related sub-commands
+  param      Various param related sub-commands
+  pkg        Various package related sub-commands
+  run        Run a package specific executable
+  service    Various service related sub-commands
+  topic      Various topic related sub-commands
+  trace      Trace ROS nodes to get information on their execution
+  wtf        Use `wtf` as alias to `doctor`
+
+  Call `ros2 <command> -h` for more detailed usage.
+```
+
+## Rebuilding Space ROS and running unit tests
+
+Space ROS sources and intermediate build artifacts are not included in the docker image.
+
+A manifest of the exact sources used to produce the current image is saved as `exact.repos` in the spaceros directory.
+To clone all sources from this manifest you can use the command sequence
+```
+spaceros-user@d10d85c68f0e:~/spaceros$ mkdir src
+spaceros-user@d10d85c68f0e:~/spaceros$ vcs import src < exact.repos
+```
+
+From there you can run a new build and any additional tests.
+```
+spaceros-user@d10d85c68f0e:~/spaceros$ colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli
+spaceros-user@d10d85c68f0e:~/spaceros$ colcon test --ctest-args -LE "(ikos|xfail)" --pytest-args -m "not xfail"
+```
+
+The tests include running the static analysis tools clang_tidy and cppcheck (which has the MISRA 2012 add-on enabled).
+
+You can use colcon's `--packages-select` option to run a subset of packages.
+For example, to run tests only for the rcpputils package and display the output directly to the console (as well as saving it to a log file), you can run:
+
+```
+spaceros-user@d10d85c68f0e:~/spaceros$ colcon test --event-handlers console_direct+ --packages-select rcpputils
+```
+
+## Viewing Test Output
+
+ The output from the tests are stored in XUnit XML files, named *\<tool-name\>*.xunit.xml.
+After running the unit tests, you can scan the build directory for the various *\*.xunit.xml* files.
+
+ For example, a clang_tidy.xunit.xml file looks like this:
+
+```xml
+<xml version="1.0" encoding="UTF-8"?>
+<testsuite
+  name="rmw.clang_tidy"
+  tests="21"
+  errors="0"
+  failures="0"
+  time="1.248"
+>
+  <testcase
+    name="/home/spaceros-user/spaceros/src/rmw/rmw/src/allocators.c"
+    classname="rmw.clang_tidy"/>
+  <testcase
+    name="/home/spaceros-user/spaceros/src/rmw/rmw/src/convert_rcutils_ret_to_rmw_ret.c"
+    classname="rmw.clang_tidy"/>
+  <testcase
+    name="/home/spaceros-user/spaceros/src/rmw/rmw/src/event.c"
+    classname="rmw.clang_tidy"/>
+  <testcase
+    name="/home/spaceros-user/spaceros/src/rmw/rmw/src/init.c"
+    classname="rmw.clang_tidy"/>
+  <testcase
+    name="/home/spaceros-user/spaceros/src/rmw/rmw/src/init_options.c"
+    classname="rmw.clang_tidy"/>
+  <testcase
+    name="/home/spaceros-user/spaceros/src/rmw/rmw/src/message_sequence.c"
+    classname="rmw.clang_tidy"/>
+  <testcase
+    name="/home/spaceros-user/spaceros/src/rmw/rmw/src/names_and_types.c"
+    classname="rmw.clang_tidy"/>
+  <testcase
+    name="/home/spaceros-user/spaceros/src/rmw/rmw/src/network_flow_endpoint.c"
+    classname="rmw.clang_tidy"/>
+  <testcase
+    name="/home/spaceros-user/spaceros/src/rmw/rmw/src/network_flow_endpoint_array.c"
+    classname="rmw.clang_tidy"/>
+  <testcase
+    name="/home/spaceros-user/spaceros/src/rmw/rmw/src/publisher_options.c"
+    classname="rmw.clang_tidy"/>
+
+<etc>
+...
+
+```
+
+## Connecting Another Terminal to a Running Docker Container
+
+Sometimes it may be convenient to attach additional terminals to a running Docker container.
+
+With the Space ROS Docker container running, open a second host terminal and then run the following command to determine the container ID:
+
+```bash
+docker container list
+```
+
+The output will look something like this:
+
+```
+CONTAINER ID   IMAGE                   COMMAND                  CREATED          STATUS          PORTS     NAMES
+d10d85c68f0e   openrobotics/spaceros   "/entrypoint.sh …"   28 minutes ago   Up 28 minutes             inspiring_moser
+```
+
+The container ID in this case, is *d10d85c68f0e*.
+So, run the following command in the host terminal:
+
+```bash
+docker exec -it d10d85c68f0e /bin/bash --init-file "install/setup.bash"
+```
+
+You will then be at a prompt in the same running container.
+
+In place of the container ID, you can also use the automatically-generated container name ("inspiring_moser" in this case).
+
+## Running an IKOS Scan
+
+IKOS uses special compiler and linker settings in order to instrument and analyze binaries.
+To run an IKOS scan on all of the Space ROS test binaries (which will take a very long time), run the following command at the root of the Space ROS workspace:
+
+```
+spaceros-user@d10d85c68f0e:~/spaceros$ CC="ikos-scan-cc" CXX="ikos-scan-c++" LD="ikos-scan-cc" colcon build --build-base build_ikos --install-base install_ikos --cmake-args -DSECURITY=ON -DINSTALL_EXAMPLES=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli
+```
+
+The previous command generates the instrumented binaries and the associated output in a separate directory from the normal Space ROS build; the command uses *--build-base* option to specify **build_ikos** as the build output directory instead of the default **build** directory.
+
+To run an IKOS scan on a specific package, such as rcpputils in this case, use the *--packages-select* option, as follows:
+
+```
+spaceros-user@d10d85c68f0e:~/spaceros$ CC="ikos-scan-cc" CXX="ikos-scan-c++" LD="ikos-scan-cc" colcon build --build-base build_ikos --install-base install_ikos --packages-select rcpputils --cmake-args -DSECURITY=ON -DINSTALL_EXAMPLES=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli
+```
+
+## Generating IKOS Results
+
+To generate JUnit XML/SARIF files for all of the binaries resulting from the build command in the previous step, you can use **colcon test**, as follows:
+
+```
+spaceros-user@d10d85c68f0e:~/spaceros$ colcon test --build-base build_ikos --install-base install_ikos --ctest-args -L "ikos"
+```
+
+To generate a JUnit XML file for a specific package only, you can add the *--packages-select* option, as follows:
+
+```
+spaceros-user@d10d85c68f0e:~/spaceros$ colcon test --build-base build_ikos --install-base install_ikos --ctest-args -L "ikos" --packages-select rcpputils
+```
+
+The `colcon test` command with the `-L "ikos"` flag runs IKOS report generation, which reads the IKOS database generated in the previous analysis step and generates a JUnit XML report file.
+After running `colcon test`, you can view the JUnit XML files.
+For example, to view the JUnit XML file for IKOS scan of the rcpputils binaries you can use the following command:
+
+```
+spaceros-user@d10d85c68f0e:~/spaceros$ more build_ikos/rcpputils/test_results/rcpputils/ikos.xunit.xml
+```
+
+SARIF files are also available in the same path:
+```
+spaceros-user@d10d85c68f0e:~/spaceros$ more build_ikos/rcpputils/test_results/rcpputils/ikos.sarif
+```
+
+## Saving build artifacts locally
+`./build.sh` script executes the Earthly `build` task defined in `Earthfile`, which copies specified artifacts from the container to the host. Additional tasks defined in the Earthfile enable the preservation of intermediate artifacts generated during the build process.
+
+For instance, the `vcs-exact` task can be utilized to copy the exact version of ROS packages pulled during the spaceros build.
+
+To invoke a task, use the following syntax:
+```bash
+earthly +TASK_NAME
+```
+
+Example:
+```
+earthly +vcs-exact
+```
+
+Refer to the [Earthfile](./Earthfile) for tasks that save artifacts locally on the host. Such tasks end with the `SAVE ARTIFACT .. AS LOCAL` syntax.

--- a/spaceros/build.sh
+++ b/spaceros/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+VCS_REF="$(git rev-parse HEAD)"
+VERSION=preview
+
+# Exit script with failure if build fails
+set -eo pipefail
+
+echo ""
+echo "##### Building Space ROS Docker Image #####"
+echo ""
+
+rm -rf src
+earthly +sources
+earthly +image \
+    --VCS_REF="$VCS_REF"
+
+echo ""
+echo "##### Done! #####"
+

--- a/spaceros/entrypoint.sh
+++ b/spaceros/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# Setup the Space ROS environment
+source "${SPACEROS_DIR}/install/setup.bash"
+export IKOS_SCAN_NOTIFIER_FILES="" # make ikos create .ikosbin files for compiled packages
+exec "$@"

--- a/spaceros/run.sh
+++ b/spaceros/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Runs a docker container with the image created by build.bash
+# Requires:
+#   docker
+#   an X server
+
+IMG_NAME=osrf/space-ros
+# Replace `/` with `_` to comply with docker container naming
+# And append `_runtime`
+CONTAINER_NAME="$(tr '/' '_' <<< "$IMG_NAME")"
+
+# Start the container
+docker run --rm -it --name $CONTAINER_NAME  --network host \
+    -e DISPLAY -e TERM   -e QT_X11_NO_MITSHM=1 $IMG_NAME


### PR DESCRIPTION
First step for: https://github.com/space-ros/space-ros/issues/158

I think I would prefer to merge this as-is, and then proceed with the remainder of the tasks from the linked issue. That'll give us the baseline from `docker` with no modifications, and ensure that modifications to the build have their own PRs. The only new change is modifying the README to point to the build directory.

If someone could trigger CI just to sanity check that moving the workflow "just works" that would be very helpful.

Once this goes in we should update/merge the corresponding change in https://github.com/space-ros/docker/pull/151.

### Moving source to preserve history

Using [git-filter-repo](https://github.com/newren/git-filter-repo?tab=readme-ov-file) to move relevant build files and workflows over to this repo from [docker](https://github.com/space-ros/docker) to preserve history. This is just the first step in the linked task.

Not sure if this is the best way to do this for a subfolder so if anyone has suggests and/or comments please fill me in. Commit history: https://github.com/eholum/space-ros/commits/move-space-ros-docker-image/spaceros

```
# Filter the docker repo to relevant files only
$ git clone https://github.com/space-ros/docker.git
$ cd docker
$ git filter-repo --path spaceros --path .github/workflows/earthly-build.yaml --force
$ cd ..

# Copied it into here...
$ git clone https://github.com/space-ros/space-ros.git
$ cd space-ros
$ git checkout -b $BRANCH_NAME
$ git remote add docker ../docker
$ git fetch docker
$ git branch docker remotes/docker/main
$ git merge docker --allow-unrelated-histories
$ git remote rm docker
$ git branch -D docker
```