### PR TITLE
Add CI step to push Docker image to ghcr.io if building main

### DIFF
--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -38,14 +38,21 @@ jobs:
         run: |
           sudo wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly
           sudo chmod 755 /usr/local/bin/earthly
+      # TODO: Set cache source to main before merging
       - name: Build spaceros image
         run: |
           earthly --ci --output +sources
-          earthly --ci +image
-      - name: Push spaceros image
+          earthly --ci --remote-cache=ghcr.io/space-ros/space-ros:push-main-image +image
+      - name: Push tagged spaceros images to Dockerhub
         env:
           DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
         if: ${{ github.ref_type == 'tag' }}
         run: |
           echo $DOCKER_HUB_TOKEN | docker login --username osrfbot --password-stdin
-          earthly --ci --push +image --tag=${{ github.ref_name }}
+          earthly --ci --push +push-image --TAG="osrf/space-ros:${{ github.ref_name }}" --LATEST="osrf/space-ros:latest"
+      # TODO: Set branch names to main before merging
+      - name: Push the main spaceros image to GHCR
+        if: ${{ github.ref_name == '194/merge' }}
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          earthly --ci --push +push-image --TAGS="ghcr.io/space-ros/space-ros:push-main-image" --LATEST=""

--- a/Earthfile
+++ b/Earthfile
@@ -257,7 +257,7 @@ build-testing:
 image:
   FROM +rosdep
   ARG VCS_REF
-  ARG tag='latest'
+  ARG VERSION="latest"
 
   # Specify the docker image metadata
   LABEL org.label-schema.schema-version="1.0"
@@ -276,4 +276,13 @@ image:
   COPY docker/entrypoint.sh /ros_entrypoint.sh
   ENTRYPOINT ["/ros_entrypoint.sh"]
   CMD ["bash"]
-  SAVE IMAGE --push osrf/space-ros:latest osrf/space-ros:$tag
+  SAVE IMAGE osrf/space-ros:${VERSION}
+
+# Target for prepping image(s) to be pushed to remote registries.
+push-image:
+  FROM +image
+
+  # This can be overridden with a blank string to prevent pushing to the registry.
+  ARG LATEST="osrf/space-ros:latest"
+  ARG TAG
+  SAVE IMAGE --push ${LATEST} ${TAG}

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 VCS_REF="$(git rev-parse HEAD)"
-VERSION=preview
+VERSION="$(git rev-parse --abbrev-ref HEAD)"
 
 # Exit script with failure if build fails
 set -eo pipefail
@@ -13,7 +13,8 @@ echo ""
 rm -rf src
 earthly +sources
 earthly +image \
-    --VCS_REF="$VCS_REF"
+        --VCS_REF="${VCS_REF}" \
+        --VERSION="${VERSION}"
 
 echo ""
 echo "##### Done! #####"


### PR DESCRIPTION
Resolves https://github.com/space-ros/space-ros/issues/193.

Adds a final step to the space ros build's CI pipeline to push the main image to the GH registry if building the `main` branch. This relies on the fact that the image produced by the Earthfile is named `osrf/space-ros:latest`. 

Some notes:

 * Should we rename the image set at the end of the Earthfile? Considering the other changes that are currently open maybe we shouldn't deal with that just yet.
 * I'll test this by running it against this branch name... and then reset it the names.
 * I dislike hardcoding everything like this but I think it makes it painfully obvious.