### PR TITLE
upgrade space-ros to jazzy/noble (closes #157)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -234,6 +234,8 @@ build:
 
 build-dev:
   FROM +rosdep
+  ARG tag='jazzy'
+
   RUN colcon build \
       --cmake-args \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -245,9 +247,11 @@ build-dev:
 
 build-testing:
   FROM +build-dev
+  # exclude ament_lint tests as they give error on Jazzy due to python 'unittest' requiring at least one test recently
   RUN . install/setup.sh && \
       colcon test \
         --retest-until-pass 2 \
+        --packages-skip ament_lint \
         --ctest-args -LE "(ikos|xfail)" \
         --pytest-args -m "not xfail"
   RUN . install/setup.sh && \

--- a/Earthfile
+++ b/Earthfile
@@ -207,7 +207,7 @@ rosdep:
         clang-14
 
   WORKDIR ${SPACEROS_DIR}
-  RUN git clone -b v3.2 --depth 1 https://github.com/NASA-SW-VnV/ikos.git
+  RUN git clone --branch v3.4 --depth 1 https://github.com/NASA-SW-VnV/ikos.git
   WORKDIR ${SPACEROS_DIR}/ikos
   RUN mkdir build
   WORKDIR ${SPACEROS_DIR}/ikos/build
@@ -216,7 +216,7 @@ rosdep:
         -DCMAKE_BUILD_TYPE="Debug" \
         -DLLVM_CONFIG_EXECUTABLE="/usr/lib/llvm-14/bin/llvm-config" \
         ..
-  RUN make
+  RUN make -j`nproc`
   RUN sudo make install
   ENV PATH="/opt/ikos/bin/:$PATH"
   WORKDIR ${SPACEROS_DIR}

--- a/docker/scripts/generate-repos.sh
+++ b/docker/scripts/generate-repos.sh
@@ -11,7 +11,7 @@ usage() {
     echo "  --repos                     File containing a list of ROS repos to use."
     echo "                              Use as alternative to 'packages', rosinstall can generate .repos file from list of repos instead of list of packages"
     echo "  --excluded-packages         File containing a list of packages to exclude [optional] "
-    echo "  --rosdistro                 ROS2 distribution (default: humble)"
+    echo "  --rosdistro                 ROS2 distribution (default: jazzy)"
     echo "  --upstream                  Specify whether to use version tags of upstream repositories (default: true)"
     echo "  --exclude-installed         Whether to exclude already installed packages from .repos file. Installed workspaces must be sourced to make it work (default: true)"
     echo "  -h, --help                  Display this help and exit"
@@ -19,7 +19,7 @@ usage() {
 }
 
 # Initialize variables with default values
-rosdistro="humble"
+rosdistro="jazzy"
 packages=""
 outfile=""
 excluded_packages=""

--- a/ikos.repos
+++ b/ikos.repos
@@ -1,5 +1,0 @@
-repositories:
-  ikos:
-    type: git
-    url: https://github.com/NASA-SW-VnV/ikos.git
-    version: v3.2

--- a/ros2.repos
+++ b/ros2.repos
@@ -11,7 +11,7 @@ repositories:
   ament_cobra:
     type: git
     url: https://github.com/ament/ament_cobra.git
-    version: master
+    version: main
   ament_ikos:
     type: git
     url: https://github.com/ament/ament_ikos.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -11,7 +11,7 @@ repositories:
   ament_cobra:
     type: git
     url: https://github.com/ament/ament_cobra.git
-    version: main
+    version: v0.12.0
   ament_ikos:
     type: git
     url: https://github.com/ament/ament_ikos.git

--- a/ros2.repos
+++ b/ros2.repos
@@ -3,11 +3,11 @@ repositories:
   ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 1.3.10
+    version: 2.5.2
   ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: 0.10.0
+    version: 0.12.0
   ament_cobra:
     type: git
     url: https://github.com/ament/ament_cobra.git
@@ -19,7 +19,7 @@ repositories:
   ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: 1.4.0
+    version: 1.8.1
   ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
@@ -27,39 +27,39 @@ repositories:
   ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: 0.14.0
+    version: 0.16.3
   class_loader:
     type: git
     url: https://github.com/ros/class_loader.git
-    version: 2.2.0
+    version: 2.7.0
   common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 4.2.4
+    version: 5.3.5
   console_bridge_vendor:
     type: git
     url: https://github.com/ros2/console_bridge_vendor.git
-    version: 1.4.1
+    version: 1.7.1
   cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: 0.10.4
+    version: 0.10.5
   eigen3_cmake_module:
     type: git
     url: https://github.com/ros2/eigen3_cmake_module.git
-    version: 0.1.1
+    version: 0.3.0
   geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.25.7
+    version: 0.36.4
   google_benchmark_vendor:
     type: git
     url: https://github.com/ament/google_benchmark_vendor.git
-    version: 0.1.2
+    version: 0.5.0
   googletest:
     type: git
     url: https://github.com/ament/googletest.git
-    version: 1.10.9006
+    version: 1.14.9000
   iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
@@ -67,51 +67,51 @@ repositories:
   kdl_parser:
     type: git
     url: https://github.com/ros/kdl_parser.git
-    version: 2.6.4
+    version: 2.11.0
   launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: 1.0.6
+    version: 3.4.2
   launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.19.7
+    version: 0.26.5
   libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
-    version: 1.3.2
+    version: 1.7.3
   libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
-    version: 1.2.2
+    version: 1.6.3
   message_filters:
     type: git
     url: https://github.com/ros2/message_filters.git
-    version: 4.3.4
+    version: 4.11.2
   mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
-    version: 0.2.8
+    version: 0.6.1
   orocos_kdl_vendor:
     type: git
     url: https://github.com/ros2/orocos_kdl_vendor.git
-    version: 0.2.5
+    version: 0.5.1
   osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
-    version: 2.0.2
+    version: 2.1.4
   osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
-    version: 1.5.2
+    version: 2.0.0
   performance_test_fixture:
     type: git
     url: https://github.com/ros2/performance_test_fixture.git
-    version: 0.0.9
+    version: 0.2.0
   pluginlib:
     type: git
     url: https://github.com/ros/pluginlib.git
-    version: 5.1.0
+    version: 5.4.2
   process_sarif:
     type: git
     url: https://github.com/space-ros/process_sarif.git
@@ -119,132 +119,136 @@ repositories:
   pybind11_vendor:
     type: git
     url: https://github.com/ros2/pybind11_vendor.git
-    version: 2.4.2
+    version: 3.1.2
   python_cmake_module:
     type: git
     url: https://github.com/ros2/python_cmake_module.git
-    version: 0.10.0
+    version: 0.11.1
   rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 5.3.9
+    version: 9.2.3
   rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: 1.2.1
+    version: 2.0.2
   rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
-    version: 2.3.1
+    version: 3.1.0
   rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 16.0.10
+    version: 28.1.3
   rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
-    version: 3.3.14
+    version: 7.1.1
   rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: 2.4.3
+    version: 2.11.0
   rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
-    version: 5.1.6
+    version: 6.7.1
   rmw:
     type: git
     url: https://github.com/ros2/rmw.git
-    version: 6.1.2
+    version: 7.3.1
   rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
-    version: 1.3.4
+    version: 2.2.2
   rmw_dds_common:
     type: git
     url: https://github.com/ros2/rmw_dds_common.git
-    version: 1.6.0
+    version: 3.1.0
   rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: 2.8.4
+    version: 2.15.3
   robot_state_publisher:
     type: git
     url: https://github.com/ros/robot_state_publisher.git
-    version: 3.0.3
+    version: 3.3.3
   ros2_tracing:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
-    version: 4.1.1
+    version: 8.2.1
   ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.18.11
+    version: 0.32.1
   ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git
-    version: 3.2.2
+    version: 4.2.1
   ros_testing:
     type: git
     url: https://github.com/ros2/ros_testing.git
-    version: 0.4.0
+    version: 0.6.0
   rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: 3.1.5
+    version: 4.6.3
+  rosidl_core:
+    type: git
+    url: https://github.com/ros2/rosidl_core.git
+    version: 0.2.0
   rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: 1.2.0
+    version: 1.6.0
+  rosidl_dynamic_typesupport:
+    type: git
+    url: https://github.com/ros2/rosidl_dynamic_typesupport.git
+    version: 0.1.2
   rosidl_python:
     type: git
     url: https://github.com/ros2/rosidl_python.git
-    version: 0.14.4
+    version: 0.22.0
   rosidl_runtime_py:
     type: git
     url: https://github.com/ros2/rosidl_runtime_py.git
-    version: 0.9.3
+    version: 0.13.1
   rosidl_typesupport:
     type: git
     url: https://github.com/ros2/rosidl_typesupport.git
-    version: 2.0.1
+    version: 3.2.2
   rpyutils:
     type: git
     url: https://github.com/ros2/rpyutils.git
-    version: 0.2.1
+    version: 0.4.1
   spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
-    version: 1.3.1
+    version: 1.6.1
   test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git
-    version: 0.9.1
+    version: 0.11.0
   tinyxml2_vendor:
     type: git
     url: https://github.com/ros2/tinyxml2_vendor.git
-    version: 0.7.6
-  tinyxml_vendor:
-    type: git
-    url: https://github.com/ros2/tinyxml_vendor.git
-    version: 0.8.3
+    version: 0.9.1
   uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
-    version: 2.0.2
+    version: 3.0.0
   unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: 2.2.1
+    version: 2.5.0
   urdf:
     type: git
     url: https://github.com/ros2/urdf.git
-    version: 2.6.0
+    version: 2.10.0
   urdfdom:
     type: git
     url: https://github.com/ros/urdfdom.git
-    version: 3.0.2
+    version: 4.0.0
   urdfdom_headers:
     type: git
     url: https://github.com/ros/urdfdom_headers.git
-    version: 1.0.6
+    version: 1.1.1

--- a/spaceros.repos
+++ b/spaceros.repos
@@ -4,7 +4,7 @@ repositories:
   ament_cobra:
     type: git
     url: https://github.com/ament/ament_cobra.git
-    version: main
+    version: v0.12.0
   ament_ikos:
     type: git
     url: https://github.com/ament/ament_ikos.git

--- a/spaceros.repos
+++ b/spaceros.repos
@@ -4,7 +4,7 @@ repositories:
   ament_cobra:
     type: git
     url: https://github.com/ament/ament_cobra.git
-    version: master
+    version: main
   ament_ikos:
     type: git
     url: https://github.com/ament/ament_ikos.git


### PR DESCRIPTION
upgrade `space-ros` to Jazzy/Noble (ubuntu24)

current status:
* [x] cobra fix merged (https://github.com/nimble-code/Cobra/pull/68). 
* [x] new Cobra release (https://github.com/nimble-code/Cobra/issues/71)
* [x] change ament_cobra to reference new Cobra 4.8 release (https://github.com/ament/ament_cobra/pull/21)
* [x] ament_cobra release 0.12.0 (https://github.com/ament/ament_cobra/issues/23)
* [x] ikos PR to fix Ubuntu22 build (https://github.com/NASA-SW-VnV/ikos/pull/274)
* [x] need new ikos release (https://github.com/NASA-SW-VnV/ikos/issues/280)
* [x] disable tests for ament_lint as it gives error
* [x] fast-forward `jazzy` branch to `main`. there is no history on jazzy, so fast forward is ok
* [ ] optional: backport unittest fix to ament_lint/spaceros branch (discussion #218, https://github.com/ament/ament_lint/pull/507)
* [ ] add image push from space-ros jazzy branch to github registry or docker hub - to start testing downstream repos

