### PR TITLE
Adds an arm build to the earthly build workflow

### DIFF
--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -44,11 +44,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install prerequisites
+      - name: Set up docker
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: |
           brew install --cask docker
           open /Applications/Docker.app
+      - name: Wait for docker
+        timeout-minutes: 1
+        run: bash docker/scripts/wait-for-docker.sh
       - name: Login to ghcr
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -49,7 +49,7 @@ jobs:
         run: |
           brew install docker
           brew install colima
-          colima start
+          colima start --cpu 3 --memory 7
       - name: Login to ghcr
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -48,6 +48,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: |
           brew install --cask docker
+          open -a Docker
       - name: Login to ghcr
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -30,6 +30,9 @@ jobs:
           path: log/build_results_archives/${{env.archivename}}
           if-no-files-found: error
   space-ros-image:
+    outputs:
+      output_ubuntu: ${{steps.push_image.outputs.output_ubuntu-latest}}
+      output_macos: ${{steps.push_image.outputs.output_macos-14}}
     strategy:
       matrix:
         include:
@@ -47,6 +50,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install prerequisites
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        run: |
+          brew install --cask docker
       - name: Set up earthly
         run: |
           sudo wget https://github.com/earthly/earthly/releases/latest/download/${{matrix.earthly}} -O /usr/local/bin/earthly
@@ -56,13 +63,28 @@ jobs:
           earthly --ci --output +sources
           earthly --ci +image
       - name: Push tagged spaceros images to Dockerhub
+        id: push_image
         env:
           DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+          TAG: osrf/space-ros:${{ github.ref_name }}-${{ runner.arch }}
         if: ${{ github.ref_type == 'tag' }}
         run: |
           echo $DOCKER_HUB_TOKEN | docker login --username osrfbot --password-stdin
-          earthly --ci --push +push-image --TAG="osrf/space-ros:${{ github.ref_name }}" --LATEST="osrf/space-ros:latest"
+          earthly --ci --push +push-image --TAG="$TAG" --LATEST=""
+          echo "output_${{ matrix.os }}=${TAG}" >> "$GITHUB_OUTPUT"
       - name: Push the main spaceros image to GHCR
-        if: ${{ github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'main' && startsWith(matrix.os, 'ubuntu') }}
         run: |
           earthly --ci --push +push-image --TAG="ghcr.io/space-ros/space-ros:main" --LATEST=""
+  combine-manifests:
+    runs-on: ubuntu-latest
+    needs: space-ros-image
+    steps:
+      - name: Combine Manifests
+        env:
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+      - run: |
+          echo $DOCKER_HUB_TOKEN | docker login --username osrfbot --password-stdin
+          docker manifest create osrf/space-ros \
+            --amend ${{ join(needs.space-ros-image.outputs, ' --amend ') }}
+          docker manifest push osrf/space-ros:${{ github.ref_name }}

--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -31,25 +31,21 @@ jobs:
           if-no-files-found: error
   space-ros-image:
     outputs:
-      output_ubuntu: ${{steps.push_image.outputs.output_ubuntu-latest}}
-      output_macos: ${{steps.push_image.outputs.output_macos-14}}
+      output_amd: ${{ steps.push_image.outputs.output_linux-amd64 }}
+      output_arm: ${{ steps.push_image.outputs.output_linux-arm64 }}
     strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            earthly: earthly-linux-amd64
-          - os: macos-14
-            earthly: earthly-darwin-arm64
-    runs-on: ${{ matrix.os }}
+      matrix: 
+        platform: [linux/amd64, linux/arm64]
+    runs-on: ubuntu-latest
     steps:
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up docker on Mac
-        if: ${{ startsWith(matrix.os, 'macos') }}
-        run: |
-          brew install docker
-          brew install colima
-          colima start --cpu 3 --memory 7
       - name: Login to ghcr
         uses: docker/login-action@v3
         with:
@@ -58,24 +54,25 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up earthly
         run: |
-          sudo wget https://github.com/earthly/earthly/releases/latest/download/${{matrix.earthly}} -O /usr/local/bin/earthly
+          sudo wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly
           sudo chmod 755 /usr/local/bin/earthly
       - name: Build spaceros image
         run: |
-          earthly --ci --output +sources
-          earthly --ci +image
+          earthly --ci --platform=${{ matrix.platform }} --output +sources
+          earthly --ci --platform=${{ matrix.platform }} +image
       - name: Push tagged spaceros images to Dockerhub
         id: push_image
         env:
           DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
-          TAG: osrf/space-ros:${{ github.ref_name }}-${{ runner.arch }}
         if: ${{ github.ref_type == 'tag' }}
         run: |
           echo $DOCKER_HUB_TOKEN | docker login --username osrfbot --password-stdin
-          earthly --ci --push +push-image --TAG="$TAG" --LATEST=""
-          echo "output_${{ matrix.os }}=${TAG}" >> "$GITHUB_OUTPUT"
+          PF=$(sed 's/\//-/g' <(echo ${{ matrix.platform }}))
+          TAG=osrf/space-ros:${{ github.ref_name }}-${PF}
+          earthly --ci --platform=${{ matrix.platform }} --push +push-image --TAG="${TAG}" --LATEST=""
+          echo "output_${PF}=${TAG}" >> "$GITHUB_OUTPUT"
       - name: Push the main spaceros image to GHCR
-        if: ${{ github.ref_name == 'main' && startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ github.ref_name == 'main' && contains(matrix.platform, 'amd') }}
         run: |
           earthly --ci --push +push-image --TAG="ghcr.io/space-ros/space-ros:main" --LATEST=""
   combine-manifests:
@@ -87,6 +84,6 @@ jobs:
           DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
         run: |
           echo $DOCKER_HUB_TOKEN | docker login --username osrfbot --password-stdin
-          docker manifest create osrf/space-ros \
+          docker manifest create osrf/space-ros:${{ github.ref_name }} \
             --amend ${{ join(needs.space-ros-image.outputs, ' --amend ') }}
           docker manifest push osrf/space-ros:${{ github.ref_name }}

--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -30,7 +30,14 @@ jobs:
           path: log/build_results_archives/${{env.archivename}}
           if-no-files-found: error
   space-ros-image:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            earthly: earthly-linux-amd64
+          - os: macos-14
+            earthly: earthly-darwin-arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -42,7 +49,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up earthly
         run: |
-          sudo wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly
+          sudo wget https://github.com/earthly/earthly/releases/latest/download/${{matrix.earthly}} -O /usr/local/bin/earthly
           sudo chmod 755 /usr/local/bin/earthly
       - name: Build spaceros image
         run: |

--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -44,16 +44,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install prerequisites
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        run: |
+          brew install --cask docker
       - name: Login to ghcr
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install prerequisites
-        if: ${{ startsWith(matrix.os, 'macos') }}
-        run: |
-          brew install --cask docker
       - name: Set up earthly
         run: |
           sudo wget https://github.com/earthly/earthly/releases/latest/download/${{matrix.earthly}} -O /usr/local/bin/earthly

--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: |
           brew install --cask docker
-          open -a Docker
+          open /Applications/Docker.app
       - name: Login to ghcr
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -44,14 +44,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up docker
+      - name: Set up docker on Mac
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: |
-          brew install --cask docker
-          open /Applications/Docker.app
-      - name: Wait for docker
-        timeout-minutes: 1
-        run: bash docker/scripts/wait-for-docker.sh
+          brew install docker
+          brew install colima
+          colima start
       - name: Login to ghcr
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Combine Manifests
         env:
           DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
-      - run: |
+        run: |
           echo $DOCKER_HUB_TOKEN | docker login --username osrfbot --password-stdin
           docker manifest create osrf/space-ros \
             --amend ${{ join(needs.space-ros-image.outputs, ' --amend ') }}

--- a/docker/scripts/wait-for-docker.sh
+++ b/docker/scripts/wait-for-docker.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-while [[ -z "$(! docker stats --no-stream 2> /dev/null)" ]];
-  do sleep 1
-done

--- a/docker/scripts/wait-for-docker.sh
+++ b/docker/scripts/wait-for-docker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+while [[ -z "$(! docker stats --no-stream 2> /dev/null)" ]];
+  do sleep 1
+done


### PR DESCRIPTION
Adds an arm64 build to Earthfile and configures the earthly-build workflow to build for linux/arm64 and linux/amd64 platforms following https://docs.earthly.dev/docs/guides/multi-platform.

Tested by building all platforms locally on a linux/arm64 machine.

~~Creates an arm64 build using a macos github runner.~~

resolves #171
