### PR TITLE
Push main Space ROS images to Dockerhub

### DIFF
--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -48,14 +48,26 @@ jobs:
         run: |
           earthly --ci --output +sources
           earthly --ci +image
-      - name: Push tagged spaceros images to Dockerhub
+      # Only push to latest if we are building a release
+      - name: Set latest image tag
+        id: set_build_tags
+        run: |
+          if [ "${{ github.ref_type }}" == "tag" ]; then
+            echo "latest_image_tag=osrf/space-ros:latest" >> $GITHUB_ENV
+          fi
+        env:
+          latest_image_tag: ""
+      # Push both tagged releases and the latest main builds to Dockerhub
+      - name: Push spaceros images to Dockerhub
+        if: ${{ github.ref_type == 'tag' || github.ref_name == 'main' }}
         env:
           DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
-        if: ${{ github.ref_type == 'tag' }}
+          LATEST_IMAGE_TAG: ${{ env.latest_image_tag }}
         run: |
           echo $DOCKER_HUB_TOKEN | docker login --username osrfbot --password-stdin
-          earthly --ci --push +push-image --TAG="osrf/space-ros:${{ github.ref_name }}" --LATEST="osrf/space-ros:latest"
+          earthly --ci --push +push-image --TAG="osrf/space-ros:${{ github.ref_name }}" --LATEST="$LATEST_IMAGE_TAG"
+      # Only push the main builds to GHCR
       - name: Push the main spaceros image to GHCR
         if: ${{ github.ref_name == 'main' }}
         run: |
-          earthly --ci --push +push-image --TAG="ghcr.io/space-ros/space-ros:main" --LATEST=""
+          earthly --ci --push +push-image --TAG="ghcr.io/space-ros/space-ros:${{ github.ref_name }}" --LATEST=""


### PR DESCRIPTION
Resolves https://github.com/space-ros/space-ros/issues/219

Adds a CI step to determine the correct tag/whether or not to tag as latest, then passes the parameterized vars for the Earthfile to the build and push step for Dockerhub. This should ensure that `main` images are pushed to Dockerhub as well. This will unblock CI for the docker repo, as well as help external users build off `main`.