### PR TITLE
Login from the CLI for Dockerhub

### DIFF
--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -73,22 +73,19 @@ jobs:
           docker push "$GHCR_IMAGE_NAME:$IMAGE_TAG"
 
       # Push both tagged releases and the latest main builds to Dockerhub
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        if: ${{ github.ref_type == 'tag' || github.ref_name == 'main' }}
-        with:
-          username: $DOCKER_HUB_USERNAME
-          password: $DOCKER_HUB_TOKEN
-
       - name: Push spaceros images to Dockerhub
         if: ${{ github.ref_type == 'tag' || github.ref_name == 'main' }}
         run: |
+          # We must login using the password and not the action, as the action only supports tokens.
+          echo "$DOCKER_HUB_TOKEN" | docker login --username "$DOCKER_HUB_USERNAME" --password-stdin
           docker push "$DOCKER_HUB_IMAGE_NAME:$IMAGE_TAG"
 
       # Any tagged image should also be marked as "latest"
       - name: Push spaceros latest images to Dockerhub
         if: ${{ github.ref_type == 'tag' }}
         run: |
+          # We must login using the password and not the action, as the action only supports tokens.
+          echo "$DOCKER_HUB_TOKEN" | docker login --username "$DOCKER_HUB_USERNAME" --password-stdin
           docker tag "$DOCKER_HUB_IMAGE_NAME:$IMAGE_TAG" "$DOCKER_HUB_IMAGE_NAME:latest"
           docker push "$DOCKER_HUB_IMAGE_NAME:latest"
 
@@ -134,14 +131,9 @@ jobs:
           docker push "$GHCR_IMAGE_NAME:$IMAGE_TAG"
 
       # Push both tagged releases and the main dev builds to Dockerhub
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        if: ${{ github.ref_type == 'tag' || github.ref_name == 'main' }}
-        with:
-          username: $DOCKER_HUB_USERNAME
-          password: $DOCKER_HUB_TOKEN
-
       - name: Push spaceros images to Dockerhub
         if: ${{ github.ref_type == 'tag' || github.ref_name == 'main' }}
         run: |
+          # We must login using the password and not the action, as the action only supports tokens.
+          echo "$DOCKER_HUB_TOKEN" | docker login --username "$DOCKER_HUB_USERNAME" --password-stdin
           docker push "$DOCKER_HUB_IMAGE_NAME:$IMAGE_TAG"


### PR DESCRIPTION
Resolves #297.

We should not use the action to login to dockerhub, as the secret in our repo is a password.