### PR TITLE
Update markdown link check (fix #299)

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: tcort/github-action-markdown-link-check@v1


### PR DESCRIPTION
Updates the markdown link check in github workflows. The previous version was deprecated in 4/25. Hopefully this will fix #299 