### PR TITLE
remove ubuntu user from ubuntu24 base image before creating spaceros user (#263)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -381,6 +381,13 @@ image:
   # Post Installation cleanup
   DO +POST_INSTALLATION --IMAGE_VARIANT=${IMAGE_VARIANT}
 
+  # fix ubuntu24 issue. 
+  # some base ubuntu24 docker images have uid 1000 for 'ubuntu' user (ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash).
+  # this is a change in behaviour from ubuntu22 base images where there was no uid 1000.
+  # this clashes with default host uid of 1000 later when tryin to mount external volumes from host.
+  # https://askubuntu.com/questions/1513927/ubuntu-24-04-docker-images-now-includes-user-ubuntu-with-uid-gid-1000
+  RUN userdel -r ubuntu
+
   # Add user and group
   RUN useradd --create-home -m -s /bin/bash ${USERNAME} && \
       echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME} && \


### PR DESCRIPTION
this is to replace PR https://github.com/space-ros/space-ros/pull/264 which had some discussion on why we do this, but i could not find ways to rebase that, so new PR