### PR TITLE
Remove YAML document start marker from ros2.repos (#180)

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -1,4 +1,3 @@
----
 repositories:
   ament_cmake:
     type: git

--- a/scripts/merge-repos.py
+++ b/scripts/merge-repos.py
@@ -29,4 +29,4 @@ ros2['repositories'] = sorted_repositories
 
 # Write the updated YAML back to file
 with open(output_file, 'w') as ros2_file:
-    yaml.dump(ros2, ros2_file, default_flow_style=False, explicit_start=True)
+    yaml.dump(ros2, ros2_file, default_flow_style=False, explicit_start=False)


### PR DESCRIPTION
Fixes #180.

The `merge-repos.py` script was using `explicit_start=True` when writing YAML, which adds a `---` document start marker. This causes the yamllint check in CI to fail with the `document-start: {present: false}` rule.

## Changes
- Set `explicit_start=False` in `scripts/merge-repos.py`
- Removed the existing `---` marker from `ros2.repos`