### PR TITLE
Build main image on arm

### DIFF
--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -7,6 +7,12 @@ on:
   pull_request:
   schedule:
     - cron: "0 11 * * *"
+
+# Ensures that only one workflow per branch will run at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     env:

--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -13,11 +13,25 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
-jobs:
-  build-test:
-    env:
-      VCS_REF: ${{ github.sha }}
+env:
+  VCS_REF: ${{ github.sha }}
+  GHCR_IMAGE_NAME: "ghcr.io/space-ros/space-ros"
+  DOCKER_HUB_USERNAME: osrfbot
+  DOCKER_HUB_IMAGE_NAME: "osrf/space-ros"
 
+jobs:
+  sanitize-docker-tag:
+    outputs:
+      tag_name: ${{ steps.sanitize.outputs.tag_name }}
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_TAG: "${{ github.head_ref || github.ref_name }}"
+    steps:
+      - name: Sanitize Github Refs
+        id: sanitize
+        run: echo "tag_name=${IMAGE_TAG//\//-}" >> "$GITHUB_OUTPUT"
+
+  build-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,77 +52,95 @@ jobs:
           path: log/build_results_archives/${{env.archivename}}
           if-no-files-found: error
 
-  space-ros-main-image:
-    runs-on: ubuntu-latest
-    env:
-      IMAGE_TAG: "${{ github.head_ref || github.ref_name }}"
-      VCS_REF: ${{ github.sha }}
-      GHCR_IMAGE_NAME: "ghcr.io/space-ros/space-ros"
-      DOCKER_HUB_USERNAME: osrfbot
-      DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
-      DOCKER_HUB_IMAGE_NAME: "osrf/space-ros"
 
+  space-ros-main-image:
+    needs: sanitize-docker-tag
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: "ubuntu-latest"
+            arch: "amd64"
+          - runner: "ubuntu-24.04-arm"
+            arch: "arm64"
+    outputs:
+      output_amd64: ${{ steps.push_image.outputs.output_amd64 }}
+      output_arm64: ${{ steps.push_image.outputs.output_arm64 }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      packages: write
+    env:
+      ARCH_IMAGE_TAG: "${{ needs.sanitize-docker-tag.outputs.tag_name }}-${{ matrix.arch }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Sanitize image tag
-        run: echo "IMAGE_TAG=${IMAGE_TAG//\//-}" >> "$GITHUB_ENV"
-
       - name: Set up earthly
         run: |
-          sudo wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly
+          sudo wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-${{ matrix.arch }} -O /usr/local/bin/earthly
           sudo chmod 755 /usr/local/bin/earthly
 
-      - name: Build spaceros image without pushing
-        run: |
-          earthly --ci --output +push-main-image \
-            --VCS_REF="$VCS_REF" \
-            --IMAGE_TAG="$IMAGE_TAG" \
-            --IMAGE_NAME="$DOCKER_HUB_IMAGE_NAME"
-
-      # Login and push the main builds to GHCR
       - name: Login to GHCR
         uses: docker/login-action@v3
-        if: ${{ github.ref_name == 'main' }}
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push the main spaceros image to GHCR
-        if: ${{ github.ref_name == 'main' }}
+      - name: Build spaceros image and push to GHCR
+        id: push_image
         run: |
-          docker tag "$DOCKER_HUB_IMAGE_NAME:$IMAGE_TAG" "$GHCR_IMAGE_NAME:$IMAGE_TAG"
-          docker push "$GHCR_IMAGE_NAME:$IMAGE_TAG"
+          earthly --ci --output --push +push-main-image \
+            --VCS_REF="$VCS_REF" \
+            --IMAGE_TAG="$ARCH_IMAGE_TAG" \
+            --IMAGE_NAME="$GHCR_IMAGE_NAME"
+          echo "output_${{ matrix.arch }}=$GHCR_IMAGE_NAME:$ARCH_IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
+
+  combine-main-image-manifests:
+    needs: [sanitize-docker-tag, space-ros-main-image]
+    if: ${{ github.ref_type == 'tag' || github.ref_name == 'main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    env:
+      IMAGE_TAG: "${{ needs.sanitize-docker-tag.outputs.tag_name }}"
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Push both tagged releases and the latest main builds to Dockerhub
-      - name: Push spaceros images to Dockerhub
-        if: ${{ github.ref_type == 'tag' || github.ref_name == 'main' }}
+      - name: Push spaceros images to Dockerhub with combined manifests
+        env: 
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
         run: |
           # We must login using the password and not the action, as the action only supports tokens.
           echo "$DOCKER_HUB_TOKEN" | docker login --username "$DOCKER_HUB_USERNAME" --password-stdin
-          docker push "$DOCKER_HUB_IMAGE_NAME:$IMAGE_TAG"
+          docker buildx imagetools create \
+            --tag "$DOCKER_HUB_IMAGE_NAME:$IMAGE_TAG" \
+            ${{ join(needs.space-ros-main-image.outputs, ' ') }}
 
       # Any tagged image should also be marked as "latest"
       - name: Push spaceros latest images to Dockerhub
         if: ${{ github.ref_type == 'tag' }}
+        env: 
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
         run: |
           # We must login using the password and not the action, as the action only supports tokens.
           echo "$DOCKER_HUB_TOKEN" | docker login --username "$DOCKER_HUB_USERNAME" --password-stdin
           docker tag "$DOCKER_HUB_IMAGE_NAME:$IMAGE_TAG" "$DOCKER_HUB_IMAGE_NAME:latest"
           docker push "$DOCKER_HUB_IMAGE_NAME:latest"
 
+
   space-ros-dev-image:
+    needs: sanitize-docker-tag
     runs-on: ubuntu-latest
     env:
-      IMAGE_TAG: "${{ github.head_ref || github.ref_name }}-dev"
-      VCS_REF: ${{ github.sha }}
-      GHCR_IMAGE_NAME: "ghcr.io/space-ros/space-ros"
-      DOCKER_HUB_USERNAME: osrfbot
-      DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
-      DOCKER_HUB_IMAGE_NAME: "osrf/space-ros"
-
+      IMAGE_TAG: "${{ needs.sanitize-docker-tag.outputs.tag_name }}-dev"
     steps:
       # Prevent the GitHub runner from running out of disk space.
       - name: Free Disk Space (Ubuntu)
@@ -116,9 +148,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Sanitize image tag
-        run: echo "IMAGE_TAG=${IMAGE_TAG//\//-}" >> "$GITHUB_ENV"
 
       - name: Set up earthly
         run: |
@@ -132,15 +161,15 @@ jobs:
             --IMAGE_TAG="$IMAGE_TAG" \
             --IMAGE_NAME="$DOCKER_HUB_IMAGE_NAME"
 
-      # Only push the main dev builds to GHCR
       - name: Login to GHCR
         uses: docker/login-action@v3
         if: ${{ github.ref_name == 'main' }}
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Only push the main dev builds to GHCR
       - name: Push the dev spaceros image to GHCR
         if: ${{ github.ref_name == 'main' }}
         run: |
@@ -150,6 +179,8 @@ jobs:
       # Push both tagged releases and the main dev builds to Dockerhub
       - name: Push spaceros images to Dockerhub
         if: ${{ github.ref_type == 'tag' || github.ref_name == 'main' }}
+        env: 
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
         run: |
           # We must login using the password and not the action, as the action only supports tokens.
           echo "$DOCKER_HUB_TOKEN" | docker login --username "$DOCKER_HUB_USERNAME" --password-stdin

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build_test_results.tar.bz2
+log/


### PR DESCRIPTION
Resolves https://github.com/space-ros/space-ros/issues/171 by creating arm versions of the main image (not including the dev or test image for now).

Additionally addresses https://github.com/space-ros/space-ros/issues/225#issuecomment-3092413332 (adds a concurrency check so that only one workflow is running per branch) in a separate commit. 

Also moves around common environment variables to a global level. Moves docker tag sanitation into it's own job to de-duplicate some logic there, and pushes images to ghcr.

The new workflow (for building main images) is:
1. Sanitize docker tag (this feeds into the main, and dev image workflows).
2. Build the main image with amd and arm variants:
  - At the end, the two architecture variants are both pushed to ghcr. This happens for every workflow run.
  - The two images are tagged differently (e.g. `ghcr.io/space-ros/space-ros:my-branch-amd64` and `ghcr.io/space-ros/space-ros:my-branch-arm64`)
3. Combine main image manifests (if this workflow is for main or a tag):
  - This job pulls takes both of the images built in the previous job (pulling from ghcr) and creates a [multi-arch image](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/) that gets pushed to dockerhub.
  - The image that gets pushed to dockerhub is named something like `osrf/space-ros:main`. This'll work for amd and arm machines.

Note: The combine manifests job is not verified that it works yet, but it can be verified after this PR merges and a scheduled build on main runs.