### PR TITLE
Fix Dev CI build (#323)

### DIFF
--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -101,6 +101,10 @@ jobs:
       DOCKER_HUB_IMAGE_NAME: "osrf/space-ros"
 
     steps:
+      # Prevent the GitHub runner from running out of disk space.
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+
       - name: Checkout
         uses: actions/checkout@v3
 


### PR DESCRIPTION
Uses an action to free up space on the GitHub runner so that this workflow no longer runs out of disk space.

Resolves #323 