### PR TITLE
Sanitize IMAGE_TAG for branch names with slashes (#329)

### DIFF
--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -46,6 +46,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Sanitize image tag
+        run: echo "IMAGE_TAG=${IMAGE_TAG//\//-}" >> "$GITHUB_ENV"
+
       - name: Set up earthly
         run: |
           sudo wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly
@@ -107,6 +110,9 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Sanitize image tag
+        run: echo "IMAGE_TAG=${IMAGE_TAG//\//-}" >> "$GITHUB_ENV"
 
       - name: Set up earthly
         run: |


### PR DESCRIPTION
Branch names containing `/` (e.g. `feature/foo`) break CI because slashes are invalid in Docker image tags.

This adds a sanitization step that replaces `/` with `-` in `IMAGE_TAG` before it's used. Uses bash parameter expansion to keep it simple while avoiding shell injection from malicious branch names.

Closes #329 #330