### PR TITLE
Disable hanging autosar rules (#311)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -320,6 +320,9 @@ build-test:
         mypy \
         argcomplete --break-system-packages
 
+  # Disable certain autosar rules becuase they cause cobra to hang (#311).
+  RUN sed -i -e '/^A5_1_1/d' -e '/^A2_11_4/d' /opt/ros/spaceros/share/cobra_vendor/rules/C++/*.cobra
+
   RUN . ${SPACEROS_DIR}/setup.sh && \
       colcon test \
         --install-base ${SPACEROS_DIR} \


### PR DESCRIPTION
This will only disable these rules when the test build stage runs in CI. 

I tried to find a way to disable these rules more programmatically as opposed to modifying system level files, but nothing stood out. I went this direction in the interest of saving us some CI time because with this change, tests that run cobra shouldn't run until they timeout anymore. 