### PR TITLE
Disable redundant compression of build result artifacts (#105)

### DIFF
--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -31,6 +31,7 @@ jobs:
           name: ${{env.archivename}}
           path: log/build_results_archives/${{env.archivename}}
           if-no-files-found: error
+          compression-level: 0
 
   space-ros-main-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The build results archive is already bzip2-compressed (`.tar.bz2`), but `upload-artifact@v4` applies zlib compression on top by default. This wastes CI time compressing an incompressible stream for no meaningful size reduction.

Sets `compression-level: 0` to skip the redundant compression pass.

Closes #105