### PR TITLE
Reduce core image size by 11%

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -344,13 +344,12 @@ build-test:
 prepare-image:
   FROM +pre-installation
 
-  # Add missing dependencies
-  RUN apt-get update && apt-get install -y \
+  # Add missing runtime dependencies
+  RUN apt-get update && apt-get install -y --no-install-recommends \
         libspdlog-dev \
         python3-numpy \
         tzdata \
-        sudo \
-        ros-dev-tools
+        sudo
   RUN pip3 install pyyaml \
         lark \
         packaging \
@@ -423,9 +422,9 @@ POST_INSTALLATION:
     RUN apt-get update && apt-get install -y \
           $(grep -v '^#' excluded-deps.txt) \
           && rm -rf excluded-deps.txt
-  # If Core, we only care about the install, and then clear the workspace
+  # If Core, we only care about the install, so clear the workspace and /usr/include
   ELSE
-    RUN rm -rf ${WORKSPACE_DIR}
+    RUN rm -rf ${WORKSPACE_DIR} /usr/include
   END
 
   # Clear Apt and Pip cache

--- a/Earthfile
+++ b/Earthfile
@@ -342,8 +342,8 @@ build-test:
 prepare-image:
   FROM +pre-installation
 
-  # Add missing dependencies
-  RUN apt-get update && apt-get install -y \
+  # Add missing runtime dependencies
+  RUN apt-get update && apt-get install -y --no-install-recommends \
         libspdlog-dev \
         python3-catkin-pkg \
         python3-lark \
@@ -420,7 +420,7 @@ POST_INSTALLATION:
     RUN apt-get update && apt-get install -y \
           $(grep -v '^#' excluded-deps.txt) \
           && rm -rf excluded-deps.txt
-  # If Core, we only care about the install, and then clear the workspace
+  # If Core, we only care about the install, so clear the workspace
   ELSE
     RUN rm -rf ${WORKSPACE_DIR}
   END


### PR DESCRIPTION
Resolves #354 

Using `docker image inspect osrf/space-ros:latest --format '{{.Size}}'` (for a better estimate than just docker image ls), we went from 1364306753 to 1202383773, so a reduction of 11.9%

This should not cause any problems. Spoke with this approach with @Bckempa and we agreed that unless a package is somehow using /usr/include at runtime or ros-dev-tools at runtime, there shouldn't be any problems with this. Perhaps worth ensuring that this is the case, but I'm not sure of any common tools I should check with to ensure that.