### PR TITLE
Reduce core image size (#356)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -344,13 +344,12 @@ build-test:
 prepare-image:
   FROM +pre-installation
 
-  # Add missing dependencies
-  RUN apt-get update && apt-get install -y \
+  # Add missing runtime dependencies
+  RUN apt-get update && apt-get install -y --no-install-recommends \
         libspdlog-dev \
         python3-numpy \
         tzdata \
-        sudo \
-        ros-dev-tools
+        sudo
   RUN pip3 install pyyaml \
         lark \
         packaging \
@@ -423,9 +422,9 @@ POST_INSTALLATION:
     RUN apt-get update && apt-get install -y \
           $(grep -v '^#' excluded-deps.txt) \
           && rm -rf excluded-deps.txt
-  # If Core, we only care about the install, and then clear the workspace
+  # If Core, we only care about the install, so clear the workspace and /usr/include
   ELSE
-    RUN rm -rf ${WORKSPACE_DIR}
+    RUN rm -rf ${WORKSPACE_DIR} /usr/include
   END
 
   # Clear Apt and Pip cache

--- a/Earthfile
+++ b/Earthfile
@@ -54,10 +54,16 @@ pre-installation:
   RUN mkdir -p ${WORKSPACE_DIR}
   WORKDIR ${WORKSPACE_DIR}
 
-  # Set the locale
-  RUN apt-get update && apt-get install -y locales
-  RUN locale-gen en_US en_US.UTF-8
-  RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+  # For apt installations in all layers, prevent dpkg from installing docs, man pages, and info pages
+  RUN printf 'path-exclude /usr/share/doc/*\npath-exclude /usr/share/man/*\npath-exclude /usr/share/info/*\n' \
+        > /etc/dpkg/dpkg.cfg.d/exclude-docs \
+      && rm -rf /usr/share/doc /usr/share/man /usr/share/info
+
+  # Set the locale, then remove i18n source data (no longer needed after locale generation)
+  RUN apt-get update && apt-get install -y locales \
+      && locale-gen en_US en_US.UTF-8 \
+      && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
+      && rm -rf /usr/share/i18n
   ENV LANG=en_US.UTF-8
 
   # The following commands are based on the source install for ROS 2 Rolling Ridley.
@@ -65,13 +71,8 @@ pre-installation:
   # The main variation is getting Space ROS sources instead of the Rolling sources.
 
   # Add the ROS 2 apt repository
-  RUN apt-get update && apt-get install -y \
+  RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
-        git \
-        cmake \
-        build-essential \
-        bison \
-        wget \
         gnupg \
         lsb-release \
         python3-pip \
@@ -83,12 +84,27 @@ pre-installation:
     && apt update
 
 ###############################################################################
+### Pre-Installation Build Stage
+# Extends pre-installation with build tools needed for compiling from source.
+# Only used by build-time stages (setup, sources, rosdep, build, ikos-install).
+# Separating this stage allows the below tools to be excluded from the main image.
+###############################################################################
+pre-installation-build:
+  FROM +pre-installation
+  RUN apt-get update && apt-get install -y \
+        git \
+        cmake \
+        build-essential \
+        bison \
+        wget
+
+###############################################################################
 ### Setup Stage
 # This stage is responsible for setting up the ROS 2 workspace and the required
 # dependencies for the workspace.
 ###############################################################################
 setup:
-  FROM +pre-installation
+  FROM +pre-installation-build
   # Install required software development tools and ROS tools (and vim included for convenience)
   RUN apt-get install -y python3-rosinstall-generator
 
@@ -112,7 +128,7 @@ setup:
 # test and development.
 ###############################################################################
 ikos-install:
-  FROM +pre-installation
+  FROM +pre-installation-build
 
   RUN apt-get update && apt-get install --yes \
       gcc \
@@ -205,7 +221,7 @@ sources:
 # for the ROS 2 workspace.
 ###############################################################################
 rosdep:
-  FROM +pre-installation
+  FROM +pre-installation-build
 
   # Rosdep updates
   RUN apt-get update && apt-get install -y python3-rosdep \
@@ -255,6 +271,17 @@ build:
   RUN mkdir -p ${SPACEROS_DIR}
 
   DO +BUILD_WORKSPACE --IMAGE_VARIANT=${IMAGE_VARIANT}
+
+  # Strip build-time-only artifacts from the install for the core image
+  # Remove .cmake files, CMakeLists, and pycache files; all unneeded at runtime
+  IF [ "${IMAGE_VARIANT}" != "dev" ]
+    RUN rm -rf ${SPACEROS_DIR}/include \
+      && find ${SPACEROS_DIR}/share -type d -name "cmake" -exec rm -rf {} + \
+      && find ${SPACEROS_DIR}/share -name "*.cmake" -delete \
+      && find ${SPACEROS_DIR}/share -name "CMakeLists.txt" -delete \
+      && find ${SPACEROS_DIR} -name "*.pyc" -delete \
+      && find ${SPACEROS_DIR} -name "__pycache__" -type d -empty -delete
+  END
 
   SAVE ARTIFACT ${SPACEROS_DIR} spaceros_install
 
@@ -347,13 +374,13 @@ prepare-image:
   # Add missing runtime dependencies
   RUN apt-get update && apt-get install -y --no-install-recommends \
         libspdlog-dev \
+        python3-netifaces \
         python3-numpy \
         tzdata \
         sudo
   RUN pip3 install pyyaml \
         lark \
         packaging \
-        netifaces \
         catkin_pkg \
         psutil --break-system-packages
 

--- a/Earthfile
+++ b/Earthfile
@@ -54,12 +54,6 @@ pre-installation:
   RUN mkdir -p ${WORKSPACE_DIR}
   WORKDIR ${WORKSPACE_DIR}
 
-  # Set the locale
-  RUN apt-get update && apt-get install -y locales
-  RUN locale-gen en_US en_US.UTF-8
-  RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
-  ENV LANG=en_US.UTF-8
-
   # The following commands are based on the source install for ROS 2 Rolling Ridley.
   # See: https://docs.ros.org/en/ros2_documentation/rolling/Installation/Ubuntu-Development-Setup.html
   # The main variation is getting Space ROS sources instead of the Rolling sources.
@@ -74,15 +68,22 @@ pre-installation:
         wget \
         gnupg \
         less \
+        locales \
         lsb-release \
         python3-pip \
         python3-setuptools \
         ssh-client \
         software-properties-common
-  RUN add-apt-repository universe
+
+  # Set the locale
+  RUN locale-gen en_US en_US.UTF-8
+  RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+  ENV LANG=en_US.UTF-8
+
+  # add-apt-repository refreshes the lists itself unless told not to
+  RUN add-apt-repository -n universe
   RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-  RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null \
-    && apt update
+  RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
 ###############################################################################
 ### Setup Stage
@@ -92,7 +93,7 @@ pre-installation:
 setup:
   FROM +pre-installation
   # Install required software development tools and ROS tools (and vim included for convenience)
-  RUN apt-get install -y --no-install-recommends python3-rosinstall-generator
+  RUN apt-get update && apt-get install -y --no-install-recommends python3-rosinstall-generator
 
   COPY scripts ./
   COPY excluded-pkgs.txt spaceros-pkgs.txt spaceros.repos ./

--- a/Earthfile
+++ b/Earthfile
@@ -73,7 +73,8 @@ pre-installation:
         python3-pip \
         python3-setuptools \
         ssh-client \
-        software-properties-common
+        software-properties-common \
+      && rm -rf /var/lib/apt/lists/*
 
   # Set the locale
   RUN locale-gen en_US en_US.UTF-8
@@ -360,12 +361,14 @@ prepare-image:
         python3-psutil \
         ros-dev-tools \
         sudo \
-        tzdata
+        tzdata \
+      && rm -rf /var/lib/apt/lists/*
 
   # Prepare the image
   RUN mkdir -p ${SPACEROS_DIR}
   COPY +rosdep/rosdeps.sh ${SPACEROS_DIR}/rosdeps.sh
-  RUN bash ${SPACEROS_DIR}/rosdeps.sh
+  RUN bash ${SPACEROS_DIR}/rosdeps.sh \
+      && rm -rf /var/lib/apt/lists/*
 
 ###############################################################################
 ### Prepare Image Stage

--- a/Earthfile
+++ b/Earthfile
@@ -65,7 +65,7 @@ pre-installation:
   # The main variation is getting Space ROS sources instead of the Rolling sources.
 
   # Add the ROS 2 apt repository
-  RUN apt-get update && apt-get install -y \
+  RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         git \
         cmake \
@@ -92,7 +92,7 @@ pre-installation:
 setup:
   FROM +pre-installation
   # Install required software development tools and ROS tools (and vim included for convenience)
-  RUN apt-get install -y python3-rosinstall-generator
+  RUN apt-get install -y --no-install-recommends python3-rosinstall-generator
 
   COPY scripts ./
   COPY excluded-pkgs.txt spaceros-pkgs.txt spaceros.repos ./
@@ -116,7 +116,7 @@ setup:
 ikos-install:
   FROM +pre-installation
 
-  RUN apt-get update && apt-get install --yes \
+  RUN apt-get update && apt-get install --yes --no-install-recommends \
       gcc \
       g++ \
       cmake \
@@ -158,7 +158,7 @@ ikos-install:
 
 ADD_IKOS:
   FUNCTION
-    RUN apt-get update && apt-get install -y \
+    RUN apt-get update && apt-get install -y --no-install-recommends \
           gcc \
           g++ \
           cmake \
@@ -192,7 +192,7 @@ ADD_IKOS:
 sources:
   FROM +setup
 
-  RUN apt-get update && apt-get install -y python3-vcstool
+  RUN apt-get update && apt-get install -y --no-install-recommends python3-vcstool
   RUN mkdir src -p \
       && vcs import --retry 3 src < output.repos \
       && vcs export --exact src > exact.repos
@@ -210,7 +210,7 @@ rosdep:
   FROM +pre-installation
 
   # Rosdep updates
-  RUN apt-get update && apt-get install -y python3-rosdep \
+  RUN apt-get update && apt-get install -y --no-install-recommends python3-rosdep \
       && rosdep init \
       && rosdep update
 
@@ -233,7 +233,7 @@ rosdep:
         && echo "#!/bin/bash" > rosdeps.sh \
         && echo "apt-get update" >> rosdeps.sh \
         && echo "apt-get install -y \\" >> rosdeps.sh \
-        && grep -v -F -f excluded-deps.txt rosdeps.txt | sed 's/^/  /' >> rosdeps.sh \
+        && grep -v -F -f excluded-deps.txt rosdeps.txt | sed 's/^\( *\)apt-get install -y/\1apt-get install -y --no-install-recommends/' | sed 's/^/  /' >> rosdeps.sh \
         && chmod +x rosdeps.sh
 
   # The generated shell script is used by the prepare-image stage prior to building the image
@@ -250,7 +250,7 @@ build:
   FROM +rosdep
 
   # Uncrustify Vendor has vcstool as a dependency
-  RUN apt-get update && apt-get install -y \
+  RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-vcstool \
         python3-colcon-common-extensions
   RUN bash rosdeps.sh
@@ -301,7 +301,7 @@ build-test:
   FROM +build --IMAGE_VARIANT=dev
 
   # Install dependencies for testing
-  RUN apt-get update && apt-get install -y \
+  RUN apt-get update && apt-get install -y --no-install-recommends \
         clang-tidy \
         cppcheck \
         google-mock \
@@ -423,7 +423,7 @@ POST_INSTALLATION:
     DO +ADD_IKOS
 
     COPY excluded-deps.txt ./
-    RUN apt-get update && apt-get install -y \
+    RUN apt-get update && apt-get install -y --no-install-recommends \
           $(grep -v '^#' excluded-deps.txt) \
           && rm -rf excluded-deps.txt
   # If Core, we only care about the install, so clear the workspace

--- a/excluded-deps.txt
+++ b/excluded-deps.txt
@@ -16,3 +16,4 @@ cppcheck
 pydocstyle
 python3-nose
 google-mock
+clang-format


### PR DESCRIPTION
This builds on top of #355, and should be merged afterwards (hence the draft PR). 

This PR reduces the image size down to ~591 MB, a 773 MB or ~56% reduction from current `main`, or a ~50% reduction from #355

`docker image inspect osrf/space-ros:latest --format '{{.Size}}'` as mentioned in the previous PR yields `590865880` (590.9 MB)

EDIT (Ivan Perez): Fixes #356.