### PR TITLE
Change build command in RELEASE.md

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -5,7 +5,7 @@
 git clone https://github.com/space-ros/space-ros.git
 cd space-ros
 git checkout -b <release-id>
-earthly build +repos-file
+earthly build +setup
 git add ros2.repos
 git commit -m "Update repos file for <release-id> release"
 ```


### PR DESCRIPTION
Update the build command in the release to match the new earthly flow. `repos-file` no longer exists as a stage.