### PR TITLE
Fix CI by Using Only Apt Packages (closes #379)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -313,12 +313,9 @@ build-test:
         python3-matplotlib \
         pyflakes3 \
         python3-mypy \
+        python3-pytest-rerunfailures \
+        python3-pytest-repeat \
         python3-argcomplete
-  RUN pip3 install pytest-rerunfailures \
-        pytest-cov \
-        pytest-repeat \
-        mypy \
-        argcomplete --break-system-packages
 
   RUN . ${SPACEROS_DIR}/setup.sh && \
       colcon test \
@@ -351,13 +348,12 @@ prepare-image:
         python3-numpy \
         tzdata \
         sudo \
-        ros-dev-tools
-  RUN pip3 install pyyaml \
-        lark \
-        packaging \
-        netifaces \
-        catkin_pkg \
-        psutil --break-system-packages
+        ros-dev-tools \
+        python3-lark \
+        python3-packaging \
+        python3-netifaces \
+        python3-catkin-pkg \
+        python3-psutil
 
   # Prepare the image
   RUN mkdir -p ${SPACEROS_DIR}


### PR DESCRIPTION
Closes #379.

Replaces the `pip3`-installed packages with their `apt` equivalents in the `Earthfile`, resolving the conflict between differently-sourced package versions that was breaking CI.

The alpha-sorting of the dependency lists that was previously the 2nd commit here has been split out into its own PR, per @ivanperez-keera's request for a separate ticket/PR pair.