### PR TITLE
Update repos for jazzy-2026.07.0 (#391).

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -6,7 +6,7 @@ repositories:
   ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: 0.12.0
+    version: 0.12.1
   ament_cobra:
     type: git
     url: https://github.com/ament/ament_cobra.git
@@ -18,7 +18,7 @@ repositories:
   ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: 1.8.3
+    version: 1.8.4
   ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
@@ -30,15 +30,15 @@ repositories:
   class_loader:
     type: git
     url: https://github.com/ros/class_loader.git
-    version: 2.7.0
+    version: 2.7.1
   common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 5.3.7
+    version: 5.3.8
   console_bridge_vendor:
     type: git
     url: https://github.com/ros2/console_bridge_vendor.git
-    version: 1.7.1
+    version: 1.7.2
   cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
@@ -46,11 +46,11 @@ repositories:
   eigen3_cmake_module:
     type: git
     url: https://github.com/ros2/eigen3_cmake_module.git
-    version: 0.3.0
+    version: 0.3.1
   geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.36.20
+    version: 0.36.21
   google_benchmark_vendor:
     type: git
     url: https://github.com/ament/google_benchmark_vendor.git
@@ -70,11 +70,11 @@ repositories:
   launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: 3.4.10
+    version: 3.4.11
   launch_ros:
     type: git
     url: https://github.com/ros2/launch_ros.git
-    version: 0.26.11
+    version: 0.26.12
   libstatistics_collector:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
@@ -82,19 +82,19 @@ repositories:
   libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
-    version: 1.6.3
+    version: 1.6.4
   message_filters:
     type: git
     url: https://github.com/ros2/message_filters.git
-    version: 4.11.13
+    version: 4.11.17
   mimick_vendor:
     type: git
     url: https://github.com/ros2/mimick_vendor.git
-    version: 0.6.2
+    version: 0.6.3
   orocos_kdl_vendor:
     type: git
     url: https://github.com/ros2/orocos_kdl_vendor.git
-    version: 0.5.1
+    version: 0.5.2
   osrf_pycommon:
     type: git
     url: https://github.com/osrf/osrf_pycommon.git
@@ -106,7 +106,7 @@ repositories:
   performance_test_fixture:
     type: git
     url: https://github.com/ros2/performance_test_fixture.git
-    version: 0.2.1
+    version: 0.2.2
   pluginlib:
     type: git
     url: https://github.com/ros/pluginlib.git
@@ -126,11 +126,11 @@ repositories:
   rcl:
     type: git
     url: https://github.com/ros2/rcl.git
-    version: 9.2.9
+    version: 9.2.11
   rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: 2.0.3
+    version: 2.0.4
   rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
@@ -138,7 +138,7 @@ repositories:
   rclcpp:
     type: git
     url: https://github.com/ros2/rclcpp.git
-    version: 28.1.18
+    version: 28.1.21
   rclpy:
     type: git
     url: https://github.com/ros2/rclpy.git
@@ -146,11 +146,11 @@ repositories:
   rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: 2.11.3
+    version: 2.11.4
   rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
-    version: 6.7.5
+    version: 6.7.6
   rmw:
     type: git
     url: https://github.com/ros2/rmw.git
@@ -170,15 +170,15 @@ repositories:
   robot_state_publisher:
     type: git
     url: https://github.com/ros/robot_state_publisher.git
-    version: 3.3.3
+    version: 3.3.4
   ros2_tracing:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
-    version: 8.2.5
+    version: 8.2.6
   ros2cli:
     type: git
     url: https://github.com/ros2/ros2cli.git
-    version: 0.32.9
+    version: 0.32.11
   ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git
@@ -186,11 +186,11 @@ repositories:
   ros_testing:
     type: git
     url: https://github.com/ros2/ros_testing.git
-    version: 0.6.0
+    version: 0.6.1
   rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: 4.6.7
+    version: 4.6.9
   rosidl_core:
     type: git
     url: https://github.com/ros2/rosidl_core.git
@@ -198,7 +198,7 @@ repositories:
   rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: 1.6.0
+    version: 1.6.1
   rosidl_dynamic_typesupport:
     type: git
     url: https://github.com/ros2/rosidl_dynamic_typesupport.git
@@ -210,7 +210,7 @@ repositories:
   rosidl_runtime_py:
     type: git
     url: https://github.com/ros2/rosidl_runtime_py.git
-    version: 0.13.1
+    version: 0.13.2
   rosidl_rust:
     type: git
     url: https://github.com/ros2-rust/rosidl_rust.git
@@ -218,7 +218,7 @@ repositories:
   rosidl_typesupport:
     type: git
     url: https://github.com/ros2/rosidl_typesupport.git
-    version: 3.2.2
+    version: 3.2.3
   rpyutils:
     type: git
     url: https://github.com/ros2/rpyutils.git
@@ -226,11 +226,11 @@ repositories:
   spdlog_vendor:
     type: git
     url: https://github.com/ros2/spdlog_vendor.git
-    version: 1.6.1
+    version: 1.6.2
   test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git
-    version: 0.11.0
+    version: 0.11.1
   tinyxml2_vendor:
     type: git
     url: https://github.com/ros2/tinyxml2_vendor.git
@@ -242,11 +242,11 @@ repositories:
   unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: 2.5.0
+    version: 2.5.1
   urdf:
     type: git
     url: https://github.com/ros2/urdf.git
-    version: 2.10.0
+    version: 2.10.1
   urdfdom:
     type: git
     url: https://github.com/ros/urdfdom.git
@@ -254,4 +254,4 @@ repositories:
   urdfdom_headers:
     type: git
     url: https://github.com/ros/urdfdom_headers.git
-    version: 1.1.2
+    version: 1.1.3


### PR DESCRIPTION
Update `ros2.repos` file using `earthly +setup`.

Fixes #391.