### PR TITLE
Remove trailing spaces (#401).

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -384,7 +384,7 @@ image:
   # Post Installation cleanup
   DO +POST_INSTALLATION --IMAGE_VARIANT=${IMAGE_VARIANT}
 
-  # fix ubuntu24 issue. 
+  # fix ubuntu24 issue.
   # some base ubuntu24 docker images have uid 1000 for 'ubuntu' user (ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash).
   # this is a change in behaviour from ubuntu22 base images where there was no uid 1000.
   # this clashes with default host uid of 1000 later when tryin to mount external volumes from host.

--- a/colcon_ws_config/spaceros_inject.cmake
+++ b/colcon_ws_config/spaceros_inject.cmake
@@ -2,7 +2,7 @@
 # include dependencies and linting tools required by spaceros
 # into every ROS package without modifying 'CMakeLists.txt' files
 
-# The code can be injected into packages with `CMAKE_PROJECT_INCLUDE` variable 
+# The code can be injected into packages with `CMAKE_PROJECT_INCLUDE` variable
 # Check: https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_INCLUDE.html
 
 cmake_minimum_required(VERSION 3.15)


### PR DESCRIPTION
This repo contains trailing spaces:

```
$ grep -nIHre ' $' . | grep -ve '\.\/src'
./colcon_ws_config/spaceros_inject.cmake:5:# The code can be injected into packages with `CMAKE_PROJECT_INCLUDE` variable
./Earthfile:387:  # fix ubuntu24 issue.
```

Trailing spaces are not needed in any of these files and some editors try to remove them automatically, causing larger diffs than intended when something else is modified in the same files. It's best if trailing spaces are intentionally removed.

This PR removes all trailing spaces in all files.

Fixes #401.