### PR TITLE
Bump actions/checkout to v7 (#406).

### DIFF
--- a/.github/workflows/earthly-build.yaml
+++ b/.github/workflows/earthly-build.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Set up earthly
         run: |
           sudo wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Sanitize image tag
         run: echo "IMAGE_TAG=${IMAGE_TAG//\//-}" >> "$GITHUB_ENV"
@@ -110,7 +110,7 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Sanitize image tag
         run: echo "IMAGE_TAG=${IMAGE_TAG//\//-}" >> "$GITHUB_ENV"

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -11,5 +11,5 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v7
     - uses: tcort/github-action-markdown-link-check@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Install dependencies
         run: python3 -m pip install vcstool yamllint
       - name: Validate formatting
@@ -27,12 +27,12 @@ jobs:
     name: Space ROS Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: space-ros/space-ros-lint-action@main
 
   commit_message_standards:
     name: Space ROS Commit Message Standards
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: space-ros/check-commit-message-action@main


### PR DESCRIPTION
Resolves #406.

Pins every `actions/checkout` use to v7: three were on v3 in `earthly-build.yaml`, one on v2 and two on v4 in `pr.yaml`, and one on the floating `@master` in `markdown-link-check.yml`.

Two changes since v4 could have affected this repo, and neither does:

- v5 moved the action to node24 and requires runner v2.327.1 or newer. Every job here runs on GitHub-hosted `ubuntu-latest`.
- v7 blocks fork-PR checkout under `pull_request_target` and `workflow_run`. Neither trigger appears in these workflows.

Independent of #388, which replaces `earthly-build.yaml` wholesale. If that lands first, this reduces to the `pr.yaml` and `markdown-link-check.yml` lines.

Verified with `workflow_dispatch` runs of both affected workflows on this branch in the PickNik fork. `Markdown Link Check` checks out on v7; its remaining failure is a dead `docs.ros.org` link that fails on `main` too.
