### PR TITLE
Fix: Fail rosdeps.sh on the first apt-get error

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -233,9 +233,10 @@ rosdep:
   # Process rosdeps.txt to a shell script
   RUN touch rosdeps.sh \
         && echo "#!/bin/bash" > rosdeps.sh \
+        && echo "set -e" >> rosdeps.sh \
         && echo "apt-get update" >> rosdeps.sh \
-        && echo "apt-get install -y \\" >> rosdeps.sh \
-        && grep -v -F -f excluded-deps.txt rosdeps.txt | sed 's/^\( *\)apt-get install -y/\1apt-get install -y --no-install-recommends/' | sed 's/^/  /' >> rosdeps.sh \
+        && echo "apt-get install -y --no-install-recommends $(grep -v -F -f excluded-deps.txt rosdeps.txt \
+             | sed -n 's/^ *apt-get install -y *//p' | tr '\n' ' ')" >> rosdeps.sh \
         && chmod +x rosdeps.sh
 
   # The generated shell script is used by the prepare-image stage prior to building the image


### PR DESCRIPTION
Closes #408.

The Earthfile generated `rosdeps.sh` as an `apt-get install -y \` header followed by the raw
output of `rosdep install --simulate`, which opens with a `#[apt] Installation commands:`
comment. The trailing backslash continued into that comment, so the header did nothing and the
script instead ran one `apt-get install -y` per dependency, 28 of them, with no `set -e` to stop
at the first failure.

The generator now takes the package names out of that output and emits a single
`apt-get install -y`, with `set -e` at the top of the script.

Verified with `earthly +prepare-image`, which regenerates the script and runs it on a bare
`ubuntu:noble`. The build succeeds and installs the same 28 packages. Injecting a bogus package
mid-list and running both scripts in `osrf/space-ros:latest` gives exit 0 for the old script and
exit 100 for the new one.
